### PR TITLE
Feat/change images in profile#12

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -7,6 +7,8 @@ import Layout from "@app/components/layout";
 import Input from "@app/components/input";
 import Button from "@app/components/button";
 import { useState } from "react";
+import useMutation, { MutationResult } from "@libs/useMutaion";
+import { eventNames } from "process";
 
 interface IForm {
   nickname: string;
@@ -19,11 +21,26 @@ const Page = () => {
     watch,
     setValue,
     setError,
+    handleSubmit,
     formState: { errors },
   } = useForm<IForm>({});
-  console.log(watch());
 
+  const nickname = "hogkim";
   const [profileImageSrc, setProfileImageSrc] = useState<string | null>(null);
+  const [changeProfile, { loading, data, error }] =
+    useMutation<MutationResult>("backendAddress");
+
+  const onSubmitWithValid = (validForm: IForm) => {
+    console.log(validForm);
+    // changeProfile(validForm);
+  };
+
+  const onProfileNicknameChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const newNickname = event.target.value;
+    console.log(newNickname);
+  };
 
   const onProfileImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -50,7 +67,10 @@ const Page = () => {
   return (
     <Layout title="프로필" hasTabBar>
       <div className="flex flex-col items-center w-screen px-4 space-y-10">
-        <form className="px-4 w-full flex flex-col items-center space-y-4 static">
+        <form
+          className="px-4 w-full flex flex-col items-center space-y-4 static"
+          onSubmit={handleSubmit(onSubmitWithValid)}
+        >
           <Image
             className="rounded-full size-32"
             src={profileImageSrc || profilePic}
@@ -88,7 +108,11 @@ const Page = () => {
           <div className="flex flex-col w-full space-y-6">
             <div className="flex flex-col w-full space-y-2">
               <span className="text-sm">닉네임</span>
-              <Input type="text" register={register("nickname")} />
+              <input
+                type="text"
+                {...register("nickname", { onChange: onProfileNicknameChange })}
+                className="appearance-none w-full px-3 py-2 rounded-2xl  placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500"
+              />
             </div>
             <Button text="저장" />
           </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -38,8 +38,6 @@ const Page = () => {
       } else {
         setError("profileImage", { message: "" });
         //프로필 이미지 변경
-        // setProfileImageSrc(URL.createObjectURL(file));
-
         const reader = new FileReader();
         reader.onload = () => {
           setProfileImageSrc(reader.result as string);

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -6,31 +6,97 @@ import { useForm } from "react-hook-form";
 import Layout from "@app/components/layout";
 import Input from "@app/components/input";
 import Button from "@app/components/button";
+import { useState } from "react";
 
 interface IForm {
   nickname: string;
+  profileImage: FileList | string | null;
 }
 
 const Page = () => {
-  const { register } = useForm<IForm>();
+  const {
+    register,
+    watch,
+    setValue,
+    setError,
+    formState: { errors },
+  } = useForm<IForm>({});
+  console.log(watch());
+
+  const [profileImageSrc, setProfileImageSrc] = useState<string | null>(null);
+
+  const onProfileImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (files && files.length > 0) {
+      const file = files[0];
+      if (file && file.size > 1024 * 1024) {
+        setError("profileImage", {
+          message: "파일 크기는 1MB를 초과할 수 없습니다.",
+        });
+        setValue("profileImage", null);
+        setProfileImageSrc(null);
+      } else {
+        setError("profileImage", { message: "" });
+        //프로필 이미지 변경
+        // setProfileImageSrc(URL.createObjectURL(file));
+
+        const reader = new FileReader();
+        reader.onload = () => {
+          setProfileImageSrc(reader.result as string);
+        };
+        reader.readAsDataURL(file);
+      }
+    }
+  };
+
   return (
     <Layout title="프로필" hasTabBar>
       <div className="flex flex-col items-center w-screen px-4 space-y-10">
-        <div className="px-4 w-full flex flex-col items-center space-y-4">
+        <form className="px-4 w-full flex flex-col items-center space-y-4 static">
           <Image
             className="rounded-full size-32"
-            src={profilePic}
+            src={profileImageSrc || profilePic}
             alt="Picture of me"
-            placeholder="blur"
+            width={300}
+            height={300}
           />
-          <form className="flex flex-col w-full space-y-6">
+          <label className="absolute top-40 left-64 inline-flex items-center justify-center w-6 h-6 me-2 text-sm font-semibold text-gray-600 bg-gray-100 rounded-full">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-5.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0ZM18.75 10.5h.008v.008h-.008V10.5Z"
+              />
+            </svg>
+            <input
+              className="hidden"
+              type="file"
+              accept="image/*"
+              {...register("profileImage", { onChange: onProfileImageChange })}
+            />
+          </label>
+          <div className="flex flex-col w-full space-y-6">
             <div className="flex flex-col w-full space-y-2">
               <span className="text-sm">닉네임</span>
               <Input type="text" register={register("nickname")} />
             </div>
             <Button text="저장" />
-          </form>
-        </div>
+          </div>
+          {errors.nickname && <span>{errors.nickname.message}</span>}
+          {errors.profileImage && <span>{errors.profileImage.message}</span>}
+        </form>
         <div className="bg-white rounded-xl w-full pt-4 px-4">
           <div className="text-lg font-bold pb-2">계정 관리</div>
           <div className="flex flex-col items-center border-t-2 py-4 space-y-3">

--- a/src/libs/useMutaion.tsx
+++ b/src/libs/useMutaion.tsx
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { useState } from "react";
 
 export interface MutationResult {
@@ -6,10 +7,11 @@ export interface MutationResult {
 
 interface UseMutationState<T> {
   loading: boolean;
-  data: T;
-  error: undefined | any;
+  data?: T;
+  error?: object;
 }
 
+// useMutationd의 Return값, [api에 post하는 함수, UseMutationState<T>객체]
 type UseMutationResult<T> = [(data: any) => void, UseMutationState<T>];
 
 export default function useMutation<T = any>(
@@ -20,22 +22,22 @@ export default function useMutation<T = any>(
     data: undefined,
     error: undefined,
   });
-  const [loading, setLoading] = useState<boolean>(false);
-  const [data, setData] = useState<undefined | any>(undefined);
-  const [error, setError] = useState<undefined | any>(undefined);
+
   function mutation(data: any) {
-    setLoading(true);
-    fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(data),
-    })
-      .then((response) => response.json().catch(() => {}))
-      .then((json) => setData(json))
-      .catch((error) => setError(error))
-      .finally(() => setLoading(false));
+    setState((prev) => ({ ...prev, loading: true }));
+
+    axios
+      .post(url, data, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+      .then((response) =>
+        setState((prev) => ({ ...prev, data: response.data, loading: false }))
+      )
+      .catch((error) =>
+        setState((prev) => ({ ...prev, error, loading: true }))
+      );
   }
-  return [mutation, { loading, data, error }];
+  return [mutation, { ...state }];
 }


### PR DESCRIPTION
프로필 이미지파트를 구현했습니다.

이미지는 1차적으로 input컴포넌트에서 jpeg, jpg, gif, png만 허용가능하도록 하였으나,
파일을 제출 시 옵션 보기 버튼을 누른 후 모든 파일로 설정하면 다른 형식의 확장자도 넣을 수 있는 문제점이 확인 되었습니다.

따라서
onChange가 감지되면, extension을 검사해주도록 하였습니다.
onChange의 validate순서는 
1. fileExtension을 검사합니다.
2. file Size를 검사합니다.