### PR TITLE
Feat/회원가입 로직 구현#16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.6.5",
+        "http-status-codes": "^2.3.0",
         "next": "14.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2456,6 +2457,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
     },
     "node_modules/ignore": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.6.5",
+    "http-status-codes": "^2.3.0",
     "next": "14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/api/apiManager.ts
+++ b/src/api/apiManager.ts
@@ -1,12 +1,18 @@
 "use client";
 
 import axios, { AxiosInstance } from "axios";
+const getAccessToken = () => {
+  if (typeof window !== "undefined") {
+    return sessionStorage.getItem("accessToken");
+  }
+  return null;
+};
 
 const apiManager: AxiosInstance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_BACKEND_SERVER}`,
   timeout: 3000,
   headers: {
-    Authorization: `Bearer ${sessionStorage.getItem("accessToken")}`,
+    Authorization: `Bearer ${getAccessToken()}`,
   },
 });
 

--- a/src/api/apiManager.ts
+++ b/src/api/apiManager.ts
@@ -1,8 +1,13 @@
-import axios, {AxiosInstance} from 'axios';
+"use client";
+
+import axios, { AxiosInstance } from "axios";
 
 const apiManager: AxiosInstance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_BACKEND_SERVER}`,
   timeout: 3000,
+  headers: {
+    Authorization: `Bearer ${sessionStorage.getItem("accessToken")}`,
+  },
 });
 
 export default apiManager;

--- a/src/app/components/googleCustomButton.tsx
+++ b/src/app/components/googleCustomButton.tsx
@@ -1,7 +1,7 @@
 import CustomButton from "./customButton";
 
 const GoogleCustomButton = () => {
-  const handleGoogleLogin = async () => {
+  const handleGoogleLogin = () => {
     try {
       window.location.href =
         "http://localhost:8080/oauth2/authorization/google";

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -31,6 +31,8 @@ function Page() {
         nickname,
       });
       if (res.status === StatusCodes.CREATED) {
+        const { accessToken } = res.data;
+        sessionStorage.setItem("accessToken", accessToken);
         router.push("/my_challenge");
       }
       console.log(res);

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,23 +1,56 @@
 "use client";
 
-import Layout from "@app/components/layout";
-import { error } from "console";
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
 import { useForm } from "react-hook-form";
+import { StatusCodes } from "http-status-codes";
+
+import apiManager from "@api/apiManager";
+import Layout from "@app/components/layout";
 
 interface IForm {
   nickname: string;
   number: number;
 }
 
-const Page = () => {
+function Page() {
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<IForm>();
-  const onSubmit = (data: IForm) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const onSubmit = async (data: IForm) => {
     console.log(data);
+    const { nickname } = data;
+    try {
+      const res = await apiManager.post("/member", {
+        nickname,
+      });
+      if (res.status === StatusCodes.CREATED) {
+        router.push("/my_challenge");
+      }
+      console.log(res);
+    } catch (error) {
+      console.log(error);
+    }
   };
+
+  useEffect(() => {
+    const accessToken: string | null = searchParams.get("accessToken");
+
+    // 소셜 로그인을 통해 들어오지 않고 주소로 직접 접근하는 경우 로그인을 하도록 이동
+    if (accessToken === null) {
+      router.push("/");
+    } else {
+      sessionStorage.setItem("accessToken", accessToken);
+      router.replace("/onboarding");
+    }
+  }, []);
+
   return (
     <Layout canGoBack>
       <div className="mx-5">
@@ -63,6 +96,6 @@ const Page = () => {
       </div>
     </Layout>
   );
-};
+}
 
 export default Page;


### PR DESCRIPTION
# 작업 내용

## 1. 소셜 로그인 후 jwt 저장

- 백엔드에서 리다이렉트로 `/onboarding?accessToken=<token>` 을 보내줍니다.
- 쿼리 스트링으로 받은 액세스 토큰을 session storage 에 저장합니다.
- 쿼리 스트링으로 액세스 토큰을 받는 이유는 백엔드에서 response body 에 담아서 보낸 액세스 토큰을 가져올 수 없었고, 쿠키로 받으면 백엔드 요청 시 헤더에 Authorization: Bearer <token> 필드를 추가할 수 없기 때문에 쿠키를 사용할 수 없었습니다.
- URL 에 담겨온 액세스 토큰은 router.replace 함수를 이용해서 제거하긴 했지만, 브라우저에서 제거하기 전의 URL 이 남아있다가 사라집니다. 이 부분은 개선할 수 있을지 찾아봐주시면 감사하겠습니다.

## 2. POST `/member` 요청 구현

- axios 의 헤더에 Authorization: Bearer <token> 을 추가해서 백엔드에 요청 보내도록 했습니다. 
- 닉네임을 입력 후 백엔드에서 새로 발급 해주는 jwt 토큰을 session storage 에 저장합니다. 

## 3. Status code library 추가

- 200 OK, 201 Created 와 같은 서버의 응답을 enum 으로 표현해주는 라이브러리를 설치했습니다. (`http-status-code`)