### PR TITLE
[feat] 프론트 토큰 정책 코드 완료(리프레시 재발급 성공하는 케이스) #28

### DIFF
--- a/src/api/apiManager.ts
+++ b/src/api/apiManager.ts
@@ -9,6 +9,13 @@ const getAccessToken = () => {
   return null;
 };
 
+const getTokenType = () => {
+  if (typeof window !== "undefined") {
+    return sessionStorage.getItem("tokenType");
+  }
+  return null;
+};
+
 const apiManager: AxiosInstance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_BACKEND_SERVER}`,
   timeout: 3000,
@@ -17,8 +24,11 @@ const apiManager: AxiosInstance = axios.create({
 apiManager.interceptors.request.use(
   (config) => {
     const token: String | null = getAccessToken();
+    let tokenType: String | null = getTokenType();
+    if (!tokenType)
+      {tokenType = "Bearer";}
     if (token) {
-      config.headers.setAuthorization(`Bearer ${token}`);
+      config.headers.setAuthorization(`${tokenType} ${token}`);
     }
     return config;
   },

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -8,10 +8,18 @@ import { StatusCodes } from "http-status-codes";
 
 import apiManager from "@api/apiManager";
 import Layout from "@app/components/layout";
+import { AxiosError } from "axios";
 
 interface IForm {
   nickname: string;
   number: number;
+}
+
+export interface ITokenData{
+  accessToken: string;
+  expiresIn: number;
+  refreshToken: string;
+  tokenType:string;
 }
 
 function Page() {
@@ -27,12 +35,14 @@ function Page() {
     console.log(data);
     const { nickname } = data;
     try {
-      const res = await apiManager.post("/member", {
+      const res = await apiManager.post<ITokenData>("/member", {
         nickname,
       });
       if (res.status === StatusCodes.CREATED) {
-        const { accessToken } = res.data;
+        const { accessToken, refreshToken, tokenType } = res.data;
         sessionStorage.setItem("accessToken", accessToken);
+        sessionStorage.setItem("refreshToken", refreshToken);
+        sessionStorage.setItem("tokenType", tokenType);
         router.push("/my_challenge");
       }
       console.log(res);


### PR DESCRIPTION
* 서버의 액세스 & 리프레시 토큰 정책에 따라 api 맞게 프론트 코드 초안 작성
-----
* `/my_challenge` 페이지에 코드 적용

```java
if (axoisError.response && axoisError.response.status === StatusCodes.UNAUTHORIZED) {
          try {
            const refreshResponse = await apiManager.post<ITokenData>("/token", {
              grantType: 'refresh_token',
              refreshToken: sessionStorage.getItem("refreshToken")
            })
            console.log(refreshResponse.data);
            sessionStorage.setItem("accessToken", refreshResponse.data.accessToken);
            sessionStorage.setItem("refreshToken", refreshResponse.data.refreshToken);
            sessionStorage.setItem("tokenType", refreshResponse.data.tokenType);
            // 토큰 재발급 성공 시 처리
          } catch (refreshError) {
            console.log("error2");
            console.error(refreshError);
            // 토큰 재발급 실패 시 처리
          }
```
* 액세스 토큰 만료 등으로 `401 UNAUTHORIZED` 에러인 경우에만 리프레시 토큰으로 재발급 요청하게 됨
* 이외의 에러는 로그인 페이지나 이전 페이지로 redirect 등 추가 처리 필요

-----
`/apiManager`에 `grantType`을 확인하는 코드 추가
```java
config.headers.setAuthorization(`${tokenType} ${token}`);
```
* `${tokenType}` 대신 `"Bearer"` 스트링으로 넣어도 되나, 서버에서 `grantType`을 따로 보내주는 만큼 그 데이터를 사용하는 게 정확하다고 생각해서 수정

-----
* 추후 해야 할 것
: 프론트의 interceptor 등을 이용하여, 리프레시 재발급 코드를 모듈화하기
: 401 이외의 에러가 발생할 경우, 적절한 처리(로그인 페이지나 이전 페이지로 redirect 등)
: 리프레시 토큰이 만료된 경우 -> 로그인 페이지로 redirect 처리