### PR TITLE
Feat/챌린지 조회 api 연동#34

### DIFF
--- a/src/app/challenges/[id]/components/challengeTitle.tsx
+++ b/src/app/challenges/[id]/components/challengeTitle.tsx
@@ -1,13 +1,25 @@
 import Image from "next/image";
 import profilePic from "../../../../../public/profilePic.jpeg";
 
-const ChallengeTitle = () => {
+interface IChallengeTitleProps {
+  title: string;
+  remainingDays: number;
+  participants: number;
+  profileImages: string | null;
+}
+
+const ChallengeTitle = ({
+  title,
+  remainingDays,
+  participants,
+  profileImages,
+}: IChallengeTitleProps) => {
   return (
     <div className="flex items-center justify-between mt-4">
       <div className="flex flex-col">
-        <div className="text-2xl font-bold">책업일치</div>
+        <div className="text-2xl font-bold">{title}</div>
         <div className="text-xl font-[250] text-habit-gray">
-          종료까지 18일 남았습니다.
+          종료까지 {remainingDays}일 남았습니다.
         </div>
       </div>
       <div className="flex items-center px-3 space-x-2 border-2 h-11 rounded-2xl border-habit-gray">
@@ -15,20 +27,20 @@ const ChallengeTitle = () => {
           <Image
             src={profilePic}
             className="z-30 rounded-full size-9 "
-            alt="profilePicture of atendees"
+            alt="profilePicture of attendees"
           />
           <Image
             src={profilePic}
             className="z-20 rounded-full size-9"
-            alt="profilePicture of atendees"
+            alt="profilePicture of attendees"
           />
           <Image
             src={profilePic}
             className="z-10 rounded-full size-9 "
-            alt="profilePicture of atendees"
+            alt="profilePicture of attendees"
           />
         </div>
-        <div>42</div>
+        <div>{participants}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
# 작업 내용
- `/challenges/[id]/main` 페이지에서 챌린지 정보를 표시합니다.
  - 해당 페이지에서 `[id]` 값을 가져오기 위해 `usePathname()` 대신 컴포넌트의 인자로 받아옵니다.
  - 참고자료: [Dynamic Routes](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes) [next.js]
  ```typescript
  const Page = ({ params }: { params: { id: string } }) => {
    const fetchChallengeDetails = async () => {
        try {
          const res = await apiManager(`/challenge/${params.id}`);
        } catch (error) {
          console.error(error);
        }
      };
  }
  ```

- `challengeTitle` 컴포넌트는 부모 컴포넌트에서 챌린지 제목, 종료까지 남은 일수, 참여자 수, 참여자 프로필 이미지를 props 로 전달 받습니다.
  ```typescript
  // challenges/[id]/main/page.tsx (부모 컴포넌트)
  ...
  {challengeDetails && (
    <ChallengeTitle
      title={challengeDetails.title}
      remainingDays={
        differenceInDays(challengeDetails.endDate, Date.now()) + 1
      }
      participants={42}
      profileImages={challengeDetails.hostProfileImage}
    />
  )}
  ...

  // challenges/[id]/components/challengeTitle.tsx (자식 컴포넌트)
  interface IChallengeTitleProps {
    title: string;
    remainingDays: number;
    participants: number;
    profileImages: string | null;
  }
  
  const ChallengeTitle = ({
    title,
    remainingDays,
    participants,
    profileImages,
  }: IChallengeTitleProps) => {
    ...
  }
  ```
  - 참여자 수, 참여자 프로필 이미지는 백엔드에서 작업을 완료하는 대로 추가할 예정입니다.