### PR TITLE
Feat/프로필 수정 api 분리#49

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -19,8 +19,11 @@ interface IForm {
   profileImage: FileList | File | null;
 }
 
-interface IProfileDTO {
+interface INicknameDto {
   nickname: string;
+}
+
+interface IImageDto {
   imageExtension: string;
   contentLength: number;
 }
@@ -41,40 +44,56 @@ const Page = () => {
   const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
   const [previewImage, setPreviewImage] = useState<string | null>(null);
 
-  const onSubmitWithValid = async (validForm: IForm) => {
-    // changeProfile(validForm);
-    const data: IProfileDTO = {
-      nickname: validForm.nickname ? validForm.nickname : nickname,
-      imageExtension: "",
-      contentLength: 0,
+  const fetchNicknameUpdate = async (nickname: string) => {
+    const data: INicknameDto = {
+      nickname,
     };
-
-    if (
-      validForm.profileImage instanceof FileList &&
-      validForm.profileImage.length == 1
-    ) {
-      const file = validForm.profileImage[0];
-      validForm.profileImage = file;
-      data.imageExtension = imageExtension;
-      data.contentLength = file.size;
-      console.log(data);
-    }
     try {
-      console.log(validForm);
-      const res = await apiManager.patch("/member", data);
+      const res = await apiManager.patch("/member/nickname", data);
+      // TODO: 성공 메세지 표시 추가하기
       console.log(res);
-      if (res.status === HttpStatusCode.Ok && previewImage) {
-        const preSignedUrl: string = res.data;
-        const res2 = await axios.put(preSignedUrl, validForm.profileImage, {
-          headers: {
-            "Content-Type": "image/" + imageExtension,
-          },
-        });
-        console.log(res2);
-      }
     } catch (error) {
+      // TODO: 에러 메세지 표시 추가하기
       console.log(error);
     }
+  };
+
+  const onSubmitWithValid = async (validForm: IForm) => {
+    if (validForm.nickname) {
+      fetchNicknameUpdate(validForm.nickname);
+    }
+    // const data: IProfileDTO = {
+    //   nickname: validForm.nickname ? validForm.nickname : nickname,
+    //   imageExtension: "",
+    //   contentLength: 0,
+    // };
+
+    // if (
+    //   validForm.profileImage instanceof FileList &&
+    //   validForm.profileImage.length == 1
+    // ) {
+    //   const file = validForm.profileImage[0];
+    //   validForm.profileImage = file;
+    //   data.imageExtension = imageExtension;
+    //   data.contentLength = file.size;
+    //   console.log(data);
+    // }
+    // try {
+    //   console.log(validForm);
+    //   const res = await apiManager.patch("/member", data);
+    //   console.log(res);
+    //   if (res.status === HttpStatusCode.Ok && previewImage) {
+    //     const preSignedUrl: string = res.data;
+    //     const res2 = await axios.put(preSignedUrl, validForm.profileImage, {
+    //       headers: {
+    //         "Content-Type": "image/" + imageExtension,
+    //       },
+    //     });
+    //     console.log(res2);
+    //   }
+    // } catch (error) {
+    //   console.log(error);
+    // }
   };
 
   const onProfileNicknameChange = (

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -19,6 +19,11 @@ interface IForm {
   profileImage: FileList | File | null;
 }
 
+interface IProfileDTO {
+  nickname: string;
+  imageUrl: string;
+}
+
 interface INicknameDto {
   nickname: string;
 }
@@ -139,8 +144,7 @@ const Page = () => {
     try {
       const res = await apiManager.get("/member");
       console.log(res);
-      const { nickname, imageUrl }: { nickname: string; imageUrl: string } =
-        res.data;
+      const { nickname, imageUrl }: IProfileDTO = res.data?.data;
 
       if (imageUrl.length > 0) {
         setProfileImageUrl(imageUrl);


### PR DESCRIPTION
# 작업 개요

마이페이지 `/profile` 에서 닉네임과 프로필 이미지를 변경하는 API 인 `PATCH /member` 를 `PATCH /member/nickname` 과 `PATCH /member/image` 로 분리해서 요청을 보내도록 수정했습니다.

# 작업 상세 내용

분리하게 된 이유는 백엔드에서 API 응답 시 response body 에 아래와 같은 구조로 보내주기 때문인데요.

```json
{
  "message": "message",
  "data": {
    "nickname": "habitpay"
  }
}
```

기존 `PATCH /member` 에서는 닉네임과 이미지를 모두 한번에 받아서 처리하다보니 경우에 따라 다른 응답을 보내주었습니다.

1. 닉네임만 수정: `프로필 업데이트에 성공했습니다.` 문자열 반환
2. 이미지만 수정: S3 업로드에 필요한 pre-signed url 반환
3. 닉네임, 이미지 모두 수정: S3 업로드에 필요한 pre-signed url 반환

하나의 API 에서 경우에 따라 다른 응답 구조를 보내는 것은 프론트엔드에서 처리하는 과정이 일관되지 않고, 백엔드에서도 테스트 코드를 작성하기 어려운 부분이 있었습니다.
따라서 일관성을 높이고, 백엔드 테스트 코드 작성의 편리함을 위해 기존의 API 를 2개의 API 로 분리했습니다.

## `onSubmitWithValid`

기존에는 닉네임과 이미지를 모두 받아서 처리하도록 했습니다.
그러다보니 코드가 복잡하고 읽기 어려운 문제가 있었습니다.
특히, S3 에 이미지를 업로드 하는 요청을 보낼 때 depth 가 깊어졌습니다.

```typescript
// 기존

const onSubmitWithValid = async (validForm: IForm) => {

  const data: IProfileDTO = {
    nickname: validForm.nickname ? validForm.nickname : nickname,
    imageExtension: "",
    contentLength: 0,
  };

  if (
    validForm.profileImage instanceof FileList &&
    validForm.profileImage.length == 1
  ) {
    const file = validForm.profileImage[0];
    validForm.profileImage = file;
    data.imageExtension = imageExtension;
    data.contentLength = file.size;
    console.log(data);
  }
  try {
    console.log(validForm);
    const res = await apiManager.patch("/member", data);
    console.log(res);
    if (res.status === HttpStatusCode.Ok && previewImage) {
      const preSignedUrl: string = res.data;
      const res2 = await axios.put(preSignedUrl, validForm.profileImage, {
        headers: {
          "Content-Type": "image/" + imageExtension,
        },
      });
      console.log(res2);
    }
  } catch (error) {
    console.log(error);
  }
};
```

가독성을 높이고, 목적에 따라 함수를 세분화하기 위해 `fetchNicknameUpdate`, `fetchPreSignedUrl`, `uploadImageToS3` 함수를 작성했습니다.

```typescript

// 변경

const onSubmitWithValid = async (validForm: IForm) => {
  if (validForm.nickname) {
    fetchNicknameUpdate(validForm.nickname);
  }
  if (
    validForm.profileImage instanceof FileList &&
    validForm.profileImage.length == 1
  ) {
    const image: File = validForm.profileImage[0];
    const preSignedUrl = await fetchPreSignedUrl(image);
    if (preSignedUrl) {
      uploadImageToS3(preSignedUrl, image);
    }
  }
};

```

## `fetchNicknameUpdate`

`PATCH /member/nickname` 으로 닉네임만 body 에 담아서 보냅니다.

```typescript
interface INicknameDto {
  nickname: string;
}

const fetchNicknameUpdate = async (nickname: string) => {
  const data: INicknameDto = {
    nickname,
  };
  try {
    const res = await apiManager.patch("/member/nickname", data);
    // TODO: 성공 메세지 표시 추가하기
    console.log(res);
  } catch (error) {
    // TODO: 에러 메세지 표시 추가하기
    console.log(error);
  }
};
```

## `fetchPreSignedUrl`

`PATCH /member/image` 는 이미지 확장자와 이미지 크기를 백엔드 서버로 보냅니다.
백엔드는 이미지 확장자와 이미지 크기에 대한 유효성 검사를 통과하면 S3 에 업로드 할 수 있는 pre-signed url 을 반환합니다.

```typescript
interface IImageDto {
  extension: string;
  contentLength: number;
}

const fetchPreSignedUrl = async (image: File) => {
  const data: IImageDto = {
    extension: imageExtension,
    contentLength: image.size,
  };
  console.log(data);
  try {
    const res = await apiManager.patch("/member/image", data);
    const { preSignedUrl } = res.data?.data;
    return preSignedUrl;
  } catch (error) {
    // TODO: 에러 메세지 표시 추가하기
    console.log(error);
    return null;
  }
};
```

## `uploadImageToS3`

`PATCH /member/image` 요청 이후 pre-signed url 을 발급 받으면 S3 로 이미지를 업로드 합니다.

```typescript
const uploadImageToS3 = async (preSignedUrl: string, image: File) => {
  try {
    const res = await axios.put(preSignedUrl, image, {
      headers: {
        "Content-Type": "image/" + imageExtension,
      },
    });
    // TODO: 성공 메세지 표시 추가하기
    console.log(res);
  } catch (error) {
    // TODO: 에러 메세지 표시 추가하기
    console.log(error);
  }
};
```

