### PR TITLE
Feat/onboarding 페이지 회원가입 후 토큰 획득 로직 삭제#48

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -38,11 +38,12 @@ function Page() {
       const res = await apiManager.post<ITokenData>("/member", {
         nickname,
       });
-      if (res.status === StatusCodes.CREATED) {
-        const { accessToken, refreshToken, tokenType } = res.data;
-        sessionStorage.setItem("accessToken", accessToken);
-        sessionStorage.setItem("refreshToken", refreshToken);
-        sessionStorage.setItem("tokenType", tokenType);
+      if (res.status === StatusCodes.OK) {
+        // TODO: 삭제 예정
+        // const { accessToken, refreshToken, tokenType } = res.data;
+        // sessionStorage.setItem("accessToken", accessToken);
+        // sessionStorage.setItem("refreshToken", refreshToken);
+        // sessionStorage.setItem("tokenType", tokenType);
         router.push("/challenges/my_challenge");
       }
       console.log(res);
@@ -59,6 +60,8 @@ function Page() {
       router.push("/");
     } else {
       sessionStorage.setItem("accessToken", accessToken);
+      // TODO: 추가 예정
+      // sessionStorage.setItem("tokenType", tokenType);
       router.replace("/onboarding");
     }
   }, []);

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -35,15 +35,17 @@ function Page() {
     console.log(data);
     const { nickname } = data;
     try {
+      // TODO: /member/activate 로 변경 예정
       const res = await apiManager.post<ITokenData>("/member", {
         nickname,
       });
       if (res.status === StatusCodes.OK) {
-        // TODO: 삭제 예정
-        // const { accessToken, refreshToken, tokenType } = res.data;
-        // sessionStorage.setItem("accessToken", accessToken);
+        // TODO: 데이터 받는 부분 수정 필요
+        const { accessToken, expiresIn, tokenType } = res.data?.data;
+        sessionStorage.setItem("accessToken", accessToken);
+        sessionStorage.setItem("expiresIn", expiresIn);
         // sessionStorage.setItem("refreshToken", refreshToken);
-        // sessionStorage.setItem("tokenType", tokenType);
+        sessionStorage.setItem("tokenType", tokenType);
         router.push("/challenges/my_challenge");
       }
       console.log(res);


### PR DESCRIPTION
# 작업 개요

- `/onboarding` 페이지에서 닉네임 입력 후 `201 Created` 대신 `200 OK` 를 받으면 `/challneges/my_challengese` 로 리다이렉트 하도록 변경했습니다.
- `POST /member` 요청 후 액세스 토큰, 리프레시 토큰, 토큰 유효시간, 토큰 유형을 response body 에 담아주었는데, 리프레시 토큰만 삭제했습니다. 최종적으로는 백엔드에서 토큰을 주지 않을 예정입니다. 백엔드 수정 후 프론트에 반영하겠습니다. 