### PR TITLE
Feat/챌린지 상세 정보 페이지 dto 변경#52

### DIFF
--- a/src/api/challenge.ts
+++ b/src/api/challenge.ts
@@ -5,8 +5,8 @@ export const fetchChallengeDetails = async (
   id: string
 ): Promise<IChallengeDetailsDto | null> => {
   try {
-    const res = await apiManager(`/challenges/${id}`);
-    const { data }: { data: IChallengeDetailsDto } = res;
+    const res = await apiManager.get(`/challenges/${id}`);
+    const { data }: { data: IChallengeDetailsDto } = res.data;
     console.log(data);
     return data;
   } catch (error) {

--- a/src/app/challenges/[id]/components/enrollment.tsx
+++ b/src/app/challenges/[id]/components/enrollment.tsx
@@ -7,12 +7,14 @@ import Button from "@app/components/button";
 
 interface IEnrollmentProps {
   id: string;
-  isEnrolledMember: boolean;
+  isMemberEnrolledInChallenge: boolean;
 }
 
-const Enrollment = ({ id, isEnrolledMember }: IEnrollmentProps) => {
-  const [isEnrolledMemberState, setIsEnrolledMemberState] =
-    useState<boolean>(isEnrolledMember);
+const Enrollment = ({ id, isMemberEnrolledInChallenge }: IEnrollmentProps) => {
+  const [
+    isMemberEnrolledInChallengeState,
+    setIsMemberEnrolledInChallengeState,
+  ] = useState<boolean>(isMemberEnrolledInChallenge);
 
   const enrollChallenge = async () => {
     try {
@@ -20,11 +22,10 @@ const Enrollment = ({ id, isEnrolledMember }: IEnrollmentProps) => {
       if (response.status === HttpStatusCode.Ok) {
         console.log(response);
         console.log("챌린지 참여 성공");
-        setIsEnrolledMemberState(true);
+        setIsMemberEnrolledInChallengeState(true);
       }
     } catch (error) {
       console.error(error);
-      console.error(error.response.data.message);
     }
   };
 
@@ -34,17 +35,16 @@ const Enrollment = ({ id, isEnrolledMember }: IEnrollmentProps) => {
       if (response.status === HttpStatusCode.Ok) {
         console.log(response);
         console.log("챌린지 참여 취소 성공");
-        setIsEnrolledMemberState(false);
+        setIsMemberEnrolledInChallengeState(false);
       }
     } catch (error) {
       console.error(error);
-      console.error(error.response.data.message);
     }
   };
 
   return (
     <>
-      {isEnrolledMemberState ? (
+      {isMemberEnrolledInChallengeState ? (
         // TODO: 빨간색으로 변경하기
         <Button onClick={cancelChallengeEnrollment} text="챌린지 참여 취소" />
       ) : (

--- a/src/app/challenges/[id]/main/page.tsx
+++ b/src/app/challenges/[id]/main/page.tsx
@@ -28,9 +28,10 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
 
   const {
     startDate,
-    isEnrolledMember,
-  }: { startDate: string; isEnrolledMember: boolean } = challengeDetails;
-  const isBeforeStartDate = isBefore(new Date(), startDate);
+    isMemberEnrolledInChallenge,
+  }: { startDate: string; isMemberEnrolledInChallenge: boolean } =
+    challengeDetails;
+  const isBeforeStartDate = isBefore(new Date(), new Date(startDate));
 
   return (
     <Layout canGoBack hasTabBar>
@@ -43,7 +44,10 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
               startDate={startDate}
               isBeforeStartDate={isBeforeStartDate}
               remainingDays={
-                differenceInDays(challengeDetails.endDate, Date.now()) + 1
+                differenceInDays(
+                  new Date(challengeDetails.endDate),
+                  Date.now()
+                ) + 1
               }
               participants={42}
               profileImages={challengeDetails.hostProfileImage}
@@ -155,7 +159,7 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
             {isBeforeStartDate ? (
               <Enrollment
                 id={id as string}
-                isEnrolledMember={isEnrolledMember}
+                isMemberEnrolledInChallenge={isMemberEnrolledInChallenge}
               />
             ) : (
               <>

--- a/src/hooks/useChallengeDetails.ts
+++ b/src/hooks/useChallengeDetails.ts
@@ -18,7 +18,7 @@ const calculateSelectedDays = (selectedDays: number[], days: number) => {
 
 export const useChallengeDetails = (id: string) => {
   const [challengeDetails, setChallengeDetails] =
-    useState<IChallengeDetailsDto | null>(challengeDetailsDtoExample);
+    useState<IChallengeDetailsDto | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [selectedDays, setSelectedDays] = useState<number[]>(

--- a/src/types/challenge/challengeDetails.interface.ts
+++ b/src/types/challenge/challengeDetails.interface.ts
@@ -8,7 +8,7 @@ export interface IChallengeDetailsDto {
   hostNickname: string;
   hostProfileImage: string | null;
   isHost: boolean;
-  isEnrolledMember: boolean;
+  isMemberEnrolledInChallenge: boolean;
 }
 
 export const challengeDetailsDtoExample = {
@@ -21,5 +21,5 @@ export const challengeDetailsDtoExample = {
   hostNickname: "string",
   hostProfileImage: null,
   isHost: true,
-  isEnrolledMember: true,
+  isMemberEnrolledInChallenge: true,
 };


### PR DESCRIPTION
# 작업 개요

`GET /challenges/[id]` 요청에 대한 백엔드 응답 DTO 변경했습니다.

# 작업 상세 내용

## 1. `response.data` 응답 구조 변경

챌린지 상세 정보를 담은 속성을 `response.data` 에서 `response.data.data` 로 변경했습니다.

**기존**
```typescript
const res = await apiManager(`/challenges/${id}`);
const { data }: { data: IChallengeDetailsDto } = res;
```

**변경**
```typescript
const res = await apiManager.get(`/challenges/${id}`);
const { data }: { data: IChallengeDetailsDto } = res.data;
```

## 2. `isEnrolledMember` 변수명 변경

사용자가 챌린지에 등록했는지 여부를 확인하는 변수 `isEnrolledMember` 에 명확한 의미를 담기 `isMemberEnrolledInChallenge` 로 변경했습니다.

```diff
export interface IChallengeDetailsDto {
  title: string;
  description: string;
  startDate: string;
  endDate: string;
  participatingDays: number;
  feePerAbsence: number;
  hostNickname: string;
  hostProfileImage: string | null;
  isHost: boolean;
+ isMemberEnrolledInChallenge: boolean;
}
```

## 3. 챌린지 상세 정보의 mock 데이터 제거

`/challenges/[id]/main` 페이지에서 임시로 보여주던 챌린지 상세 정보를 담는 state `challengeDetails` 의 초기값을 null 로 변경했습니다. 

```diff
export const useChallengeDetails = (id: string) => {
  const [challengeDetails, setChallengeDetails] =
+   useState<IChallengeDetailsDto | null>(null);
   ...
}
```