### PR TITLE
Feat/oauth 로그인 후 리다이렉션 페이지 생성#54

### DIFF
--- a/src/api/challenge.ts
+++ b/src/api/challenge.ts
@@ -1,4 +1,4 @@
-import apiManager from "@api/apiManager";
+import apiManager from "@/api/apiManager";
 import { IChallengeDetailsDto } from "@/types/challenge";
 
 export const fetchChallengeDetails = async (

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,0 +1,15 @@
+import apiManager from "@/api/apiManager";
+import { IMemberProfileDto } from "@/types/member";
+
+export const fetchMemberProfile = async (
+): Promise<IMemberProfileDto | null> => {
+  try {
+    const res = await apiManager.get(`/member`);
+    const { data }: { data: IMemberProfileDto } = res.data;
+    console.log(data);
+    return data;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+function Page() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const accessToken: string | null = searchParams.get("accessToken");
+    // 소셜 로그인을 통해 들어오지 않고 주소로 직접 접근하는 경우 로그인을 하도록 이동
+    if (accessToken === null) {
+      router.push("/");
+    } else {
+      sessionStorage.setItem("accessToken", accessToken);
+      router.push("/challenges/my_challenge");
+    }
+  }, []);
+
+  return <></>;
+}
+
+export default Page;

--- a/src/app/challenges/[id]/components/enrollment.tsx
+++ b/src/app/challenges/[id]/components/enrollment.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 
 import { HttpStatusCode } from "axios";
 
-import apiManager from "@api/apiManager";
-import Button from "@app/components/button";
+import apiManager from "@/api/apiManager";
+import Button from "@/app/components/button";
 
 interface IEnrollmentProps {
   id: string;

--- a/src/app/challenges/[id]/components/menu.tsx
+++ b/src/app/challenges/[id]/components/menu.tsx
@@ -1,4 +1,4 @@
-import { addClassNames } from "@libs/utils";
+import { addClassNames } from "@/libs/utils";
 import Link from "next/link";
 import { ReadonlyURLSearchParams } from "next/navigation";
 

--- a/src/app/challenges/[id]/edit/page.tsx
+++ b/src/app/challenges/[id]/edit/page.tsx
@@ -4,12 +4,12 @@ import { useForm } from "react-hook-form";
 import { format, differenceInDays } from "date-fns";
 import { ko } from "date-fns/locale/ko";
 
-import apiManager from "@api/apiManager";
+import apiManager from "@/api/apiManager";
 import { useChallengeDetails } from "@/hooks/useChallengeDetails";
-import Label from "@app/challenges/components/label";
-import Layout from "@app/components/layout";
-import TextArea from "@app/components/textarea";
-import { addClassNames } from "@libs/utils";
+import Label from "@/app/challenges/components/label";
+import Layout from "@/app/components/layout";
+import TextArea from "@/app/components/textarea";
+import { addClassNames } from "@/libs/utils";
 import { IChallengePatchDto } from "@/types/challenge";
 import { Days } from "@/types/enums";
 

--- a/src/app/challenges/[id]/fee_table/page.tsx
+++ b/src/app/challenges/[id]/fee_table/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Layout from "@app/components/layout";
-import { addClassNames } from "@libs/utils";
+import Layout from "@/app/components/layout";
+import { addClassNames } from "@/libs/utils";
 import { useState } from "react";
 
 interface Participant {

--- a/src/app/challenges/[id]/main/page.tsx
+++ b/src/app/challenges/[id]/main/page.tsx
@@ -5,17 +5,17 @@ import Image from "next/image";
 
 import { differenceInDays, isBefore } from "date-fns";
 
-import Layout from "@app/components/layout";
-import profilePic from "@public/profilePic.jpeg";
-import FloatingButton from "@app/components/floatingButton";
+import Layout from "@/app/components/layout";
+import profilePic from "@/public/profilePic.jpeg";
+import FloatingButton from "@/app/components/floatingButton";
 import Menu from "../components/menu";
 import ChallengeTitle from "../components/challengeTitle";
 import IsCompleteToday from "../components/isCompleteToday";
 import { useChallengeDetails } from "@/hooks/useChallengeDetails";
 import Enrollment from "../components/enrollment";
 import { usePathname } from "next/navigation";
-import { getParentPath } from "@libs/utils";
-import PostsFeed, { PostsFeedExample } from "@app/components/postsFeed";
+import { getParentPath } from "@/libs/utils";
+import PostsFeed, { PostsFeedExample } from "@/app/components/postsFeed";
 
 const Page = ({ params: { id } }: { params: { id: string } }) => {
   const { challengeDetails, isLoading, error } = useChallengeDetails(id);

--- a/src/app/challenges/[id]/participation/page.tsx
+++ b/src/app/challenges/[id]/participation/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import Layout from "@app/components/layout";
+import Layout from "@/app/components/layout";
 import Menu from "../components/menu";
 import { usePathname } from "next/navigation";
 import ChallengeTitle from "../components/challengeTitle";
 import IsCompleteToday from "../components/isCompleteToday";
 import Calendar from "react-calendar";
-import FloatingButton from "@app/components/floatingButton";
+import FloatingButton from "@/app/components/floatingButton";
 
 const Page = () => {
   const currentPath = usePathname().split("/");

--- a/src/app/challenges/[id]/post/page.tsx
+++ b/src/app/challenges/[id]/post/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Layout from "@app/components/layout";
-import { MB, validImageExtensions } from "@libs/constants";
-import { addClassNames } from "@libs/utils";
+import Layout from "@/app/components/layout";
+import { MB, validImageExtensions } from "@/libs/constants";
+import { addClassNames } from "@/libs/utils";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";

--- a/src/app/challenges/create_challenge/page.tsx
+++ b/src/app/challenges/create_challenge/page.tsx
@@ -11,12 +11,12 @@ import { DateRange, Range } from "react-date-range";
 import "react-date-range/dist/styles.css"; // main css file
 import "react-date-range/dist/theme/default.css"; // theme css file
 
-import { addClassNames } from "@libs/utils";
-import Layout from "@app/components/layout";
+import { addClassNames } from "@/libs/utils";
+import Layout from "@/app/components/layout";
 import Label from "../components/label";
-import Button from "@app/components/button";
-import { convertKstDate } from "@libs/date";
-import apiManager from "@api/apiManager";
+import Button from "@/app/components/button";
+import { convertKstDate } from "@/libs/date";
+import apiManager from "@/api/apiManager";
 import { Days, SelectedStatus } from "@/types/enums";
 import { useRouter } from "next/navigation";
 

--- a/src/app/challenges/my_challenge/components/challengesButton.tsx
+++ b/src/app/challenges/my_challenge/components/challengesButton.tsx
@@ -1,4 +1,4 @@
-import { addClassNames } from "@libs/utils";
+import { addClassNames } from "@/libs/utils";
 import { Dispatch } from "react";
 
 interface IChallengesButton {

--- a/src/app/challenges/my_challenge/loading.tsx
+++ b/src/app/challenges/my_challenge/loading.tsx
@@ -1,4 +1,4 @@
-import Layout from "@app/components/layout";
+import Layout from "@/app/components/layout";
 
 const Loading = () => {
   return (

--- a/src/app/components/button.tsx
+++ b/src/app/components/button.tsx
@@ -1,4 +1,4 @@
-import { addClassNames } from "@libs/utils";
+import { addClassNames } from "@/libs/utils";
 
 interface ButtonProps {
   large?: boolean;

--- a/src/app/components/layout.tsx
+++ b/src/app/components/layout.tsx
@@ -1,4 +1,6 @@
-import { addClassNames } from "@libs/utils";
+"use client";
+
+import { addClassNames } from "@/libs/utils";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";

--- a/src/app/components/postItem.tsx
+++ b/src/app/components/postItem.tsx
@@ -5,7 +5,7 @@ import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
-import { formatToTimeAgo } from "@libs/utils";
+import { formatToTimeAgo } from "@/libs/utils";
 
 export interface IPostDto {
   profilePic: string;

--- a/src/app/components/postsFeed.tsx
+++ b/src/app/components/postsFeed.tsx
@@ -1,4 +1,4 @@
-import Layout from "@app/components/layout";
+import Layout from "@/app/components/layout";
 import Image from "next/image";
 import PostItem, { IPostDto } from "./postItem";
 

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -6,8 +6,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { StatusCodes } from "http-status-codes";
 
-import apiManager from "@api/apiManager";
-import Layout from "@app/components/layout";
+import apiManager from "@/api/apiManager";
+import Layout from "@/app/components/layout";
 import { AxiosError } from "axios";
 
 interface IForm {

--- a/src/app/pageSample.tsx
+++ b/src/app/pageSample.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import apiManager from "@api/apiManager";
+import apiManager from "@/api/apiManager";
 import Image from "next/image";
 import { FormEvent, useEffect } from "react";
 

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Layout from "@app/components/layout";
-import PostItem from "@app/components/postItem";
-import { PostsFeedExample } from "@app/components/postsFeed";
+import Layout from "@/app/components/layout";
+import PostItem from "@/app/components/postItem";
+import { PostsFeedExample } from "@/app/components/postsFeed";
 
 const Page = () => {
   return (

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -7,12 +7,12 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import axios, { HttpStatusCode } from "axios";
-import Layout from "@app/components/layout";
-import Button from "@app/components/button";
-import profilePic from "@public/default-profile.jpeg";
-import apiManager from "@api/apiManager";
-import { removeJwtFromSessionStorage } from "@libs/jwt";
-import { MB, validImageExtensions } from "@libs/constants";
+import Layout from "@/app/components/layout";
+import Button from "@/app/components/button";
+import profilePic from "@/public/default-profile.jpeg";
+import apiManager from "@/api/apiManager";
+import { removeJwtFromSessionStorage } from "@/libs/jwt";
+import { MB, validImageExtensions } from "@/libs/constants";
 
 interface IForm {
   nickname: string;

--- a/src/app/test_page/page.tsx
+++ b/src/app/test_page/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import ErrorModal from "@app/components/errorModal";
+import ErrorModal from "@/app/components/errorModal";
 import { NextPage } from "next";
 import { useEffect, useState } from "react";
 

--- a/src/hooks/useMemberProfile.ts
+++ b/src/hooks/useMemberProfile.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+
+import {
+  IMemberProfileDto
+} from "@/types/member";
+import { fetchMemberProfile } from "@/api/member";
+
+export const useMemberProfile = () => {
+  const [memberProfile, setMemberProfile] =
+    useState<IMemberProfileDto | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await fetchMemberProfile();
+        if (data) {
+          setMemberProfile(data);
+        }
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return { memberProfile, isLoading, error };
+};

--- a/src/types/member/index.ts
+++ b/src/types/member/index.ts
@@ -1,0 +1,1 @@
+export * from "./profile.interface"

--- a/src/types/member/profile.interface.ts
+++ b/src/types/member/profile.interface.ts
@@ -1,0 +1,4 @@
+export interface IMemberProfileDto {
+	nickname: string;
+	imageUrl: string;
+  }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -2,12 +2,12 @@
   "compilerOptions": {
     "baseUrl": "src",
     "paths": {
-      "@api/*": ["api/*"],
-      "@app/*": ["app/*"],
-      "@libs/*": ["libs/*"],
+      "@/api/*": ["api/*"],
+      "@/app/*": ["app/*"],
+      "@/libs/*": ["libs/*"],
       "@/types/*": ["types/*"],
       "@/hooks/*": ["hooks/*"],
-      "@public/*": ["../public/*"]
+      "@/public/*": ["../public/*"]
     }
   }
 }


### PR DESCRIPTION
# 작업 개요

1. OAuth 로그인 후 백엔드에서 리다이렉션 주소를 `/auth` 로 변경했습니다.
2. `/challenges/my_challneges` 페이지에서 사용자의 정보를 받아오는 `useMemberProfile` 커스텀 훅을 생성했습니다.
3. 절대 경로의 네이밍 형식을 `@.../` 에서 `@/...` 로 변경했습니다. 

# 작업 상세 내용

## 1. OAuth 로그인 후 리다이렉션 주소 `/auth` 로 변경

이전에는 로그인 후 닉네임을 입력하는 `/onboarding` 페이지에서 `POST /member` 요청을 보내야만 서비스를 정상적으로 이용할 수 있었습니다.
하지만, 로직의 변경으로 닉네임 입력 과정을 생략하도록 했습니다.
초기 닉네임은 이메일 ID (@ 기준으로 좌측에 있는 문자열)로 설정됩니다. 
그리고 리프레시 토큰은 백엔드에서 쿠키로 전달합니다.

이에 따라 `/auth` 페이지에서 액세스 토큰을 세션 스토리지에 저장하고, 정상적으로 저장했다면 `/challenges/my_challenges` 페이지로 이동합니다. 
`onboarding` 페이지는 아직 삭제하지 않았으며, 혹시라도 필요할 경우를 대비해서 남겨두었습니다.

```typescript

// src/app/auth/page.tsx

useEffect(() => {
const accessToken: string | null = searchParams.get("accessToken");
// 소셜 로그인을 통해 들어오지 않고 주소로 직접 접근하는 경우 로그인을 하도록 이동
if (accessToken === null) {
  router.push("/");
} else {
  sessionStorage.setItem("accessToken", accessToken);
  router.push("/challenges/my_challenge");
}
}, []);

```

그리고 컴포넌트는 `const` 키워드가 아닌 `function` 키워드를 이용해서 컴포넌트와 내부 변수의 구분을 명확하게 하는 편인데, 이 부분에 대한 의견이 궁금합니다.

```diff
+   function Page() {
      const router = useRouter();
      const searchParams = useSearchParams();
    
      // 생략...
    
      return <></>;
    }
```

## 2. `useMemberProfile` 커스텀 훅 생성

기존에는 백엔드에서 jwt 에 닉네임을 포함해서 보내주었고, 프론트에서는 jwt 를 파싱해서 닉네임 정보를 가져오도록 했습니다.

```typescript

// src/app/challenges/my_challenge/page.tsx

const accessToken: string | null = sessionStorage.getItem("accessToken");
if (accessToken) {
  const decoded = jwtDecode<JwtPayload>(accessToken);
  setNickname(decoded.nickname);
}

```

하지만 이 방식은 사용자가 닉네임을 변경했을 때 백엔드에서 변경된 닉네임을 반영해서 새로운 jwt 를 발급해야 하는 문제가 있습니다.
그렇기에 프론트에서는 `GET /member` 요청을 보내서 닉네임과 프로필 이미지를 받아오도록 했습니다.
이를 위해 `useMemberProfile` 이라는 커스텀 훅과 response body 데이터를 받기 위한 interface 파일을 생성했습니다. 

## 3. 절대 경로 형식 변경

`tsconfig.paths.json` 파일에서 절대 경로의 형식을 변경했고, 이에 따라 다른 파일에도 변경 사항을 적용했습니다.

```json
"compilerOptions": {
  "baseUrl": "src",
  "paths": {
    "@/api/*": ["api/*"],
    "@/app/*": ["app/*"],
    "@/libs/*": ["libs/*"],
    "@/types/*": ["types/*"],
    "@/hooks/*": ["hooks/*"],
    "@/public/*": ["../public/*"]
  }
}
```