### PR TITLE
Create/infinite scroll in posts feed#47

### DIFF
--- a/src/app/challenges/[id]/main/page.tsx
+++ b/src/app/challenges/[id]/main/page.tsx
@@ -33,6 +33,33 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
     challengeDetails;
   const isBeforeStartDate = isBefore(new Date(), new Date(startDate));
 
+  // PostsFeed의 prop으로 주기위한 예시. 백엔드완성되면 삭제
+  const initialFeed = [
+    {
+      profilePic: "/profilePic.jpeg",
+      nickname: "hogkim",
+      createdAt: new Date(),
+      isNotification: true,
+      imageList: [
+        "/default-profile.jpeg",
+        "/profilePic.jpeg",
+        "/chungking_express__movie_poster__by_seblakes31_dep34tb-fullview.jpg",
+        "/manaca.JPG",
+      ],
+      contents:
+        "test contents test contents test contents test contents test contents test contents test contents test contents test contents",
+    },
+    {
+      profilePic: "/default-profile.jpeg",
+      nickname: "jkwak",
+      createdAt: new Date(),
+      isNotification: false,
+      imageList: ["/profilePic.jpeg", "/default-profile.jpeg"],
+      contents:
+        "example contents example contents example contents example contents example contents example contents example contents example contents example contents example contents example contents ",
+    },
+  ];
+
   return (
     <Layout canGoBack hasTabBar>
       <div className="flex flex-col divide-y-2">
@@ -166,7 +193,7 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
                 <span className="px-5 py-3 text-sm font-light bg-white rounded-xl">
                   어제
                 </span>
-                <PostsFeed feeds={PostsFeedExample} />
+                <PostsFeed initialFeed={initialFeed} />
                 <FloatingButton href={`${getParentPath(pathname)}/post`}>
                   <svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/src/app/components/layout.tsx
+++ b/src/app/components/layout.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-<<<<<<< HEAD
-import { addClassNames } from "@libs/utils";
-=======
 import { addClassNames } from "@/libs/utils";
->>>>>>> main
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 

--- a/src/app/components/layout.tsx
+++ b/src/app/components/layout.tsx
@@ -1,7 +1,8 @@
+"use client";
+
 import { addClassNames } from "@libs/utils";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
 
 interface LayoutProps {
   title?: string;


### PR DESCRIPTION
PostsFeed 컴포넌트로 infiniteScroll을 구현하였습니다.
초기단계이고, 백엔드 api가 완성되면 연동하는것까지 해서 완성 할 계획입니다.

인자로는 초기에 표시해줄 initialFeed를 받습니다. 이것은 PostsFeed 컴포넌트를 렌더링하는 페이지인 /challenges/[id]/main에서 넘겨줍니다. 37번줄에 initialFeed의 example을 두었고 나중에 지울것입니다.

PostsFeed페이지의 getMoreFeed함수로 포스트 하나를 더 불러오는 방식으로 우선 구현해뒀습니다.
하나씩 불러오게 되어있습니다. <span>을 화면에서 감지하면 getMoreFeed함수가 실행되며 Feed에 Post가 하나씩 늘어갑니다.
