### PR TITLE
♻️ refactor: 챌린지 전체 참여 일수 변수명 변경 #60

### DIFF
--- a/src/app/challenges/my_challenge/components/challengeCard.tsx
+++ b/src/app/challenges/my_challenge/components/challengeCard.tsx
@@ -17,7 +17,7 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
     <>
       {items.map((item, index) => {
         const progressPercent: number =
-          (item.successCount / item.totalParticipatingDays) * 100;
+          (item.successCount / item.totalParticipatingDaysCount) * 100;
 
         return (
           <div

--- a/src/types/challenge/challengeEnrolledListItem.interface.ts
+++ b/src/types/challenge/challengeEnrolledListItem.interface.ts
@@ -4,7 +4,7 @@ export interface IChallengeEnrolledListItemDto {
   startDate: string;
   endDate: string;
   stopDate: string;
-  totalParticipatingDays: number;
+  totalParticipatingDaysCount: number;
   numberOfParticipants: number;
   participatingDays: number;
   totalFee: number;


### PR DESCRIPTION
# 작업 개요

백엔드에서 보내주는 DTO 변수명 변경에 따라 `totalParticipatingDays` 를 `totalParticipatingDaysCount` 로 변경했습니다. 

```diff
export interface IChallengeEnrolledListItemDto {
  title: string;
  description: string;
  startDate: string;
  endDate: string;
  stopDate: string;
- totalParticipatingDays: number;
+ totalParticipatingDaysCount: number;
  numberOfParticipants: number;
  participatingDays: number;
  totalFee: number;
  isPaidAll: boolean;
  hostProfileImage: string | null;
  isMemberGivenUp: boolean;
  successCount: number;
  isTodayParticipatingDay: boolean;
  isParticipatedToday: boolean;
}
```