### PR TITLE
Feat/챌린지 메인 페이지 참여자 프로필 이미지 추가#62

### DIFF
--- a/src/app/challenges/[id]/components/challengeTitle.tsx
+++ b/src/app/challenges/[id]/components/challengeTitle.tsx
@@ -34,11 +34,12 @@ const ChallengeTitle = ({
       </div>
       <div className="flex items-center px-3 space-x-2 border-2 h-11 rounded-2xl border-habit-gray">
         <div className="flex -space-x-2">
-          {profileImages.map((profileImage) => {
+          {profileImages.map((profileImage, index) => {
+            const className=`z-${30 - index * 10}30 rounded-full size-9`;
             return (
               <Image
                 src={profileImage || defaultProfileImage}
-                className="z-30 rounded-full size-9 "
+                className={className}
                 alt="profile image"
                 width={36}
                 height={36}

--- a/src/app/challenges/[id]/components/challengeTitle.tsx
+++ b/src/app/challenges/[id]/components/challengeTitle.tsx
@@ -6,7 +6,7 @@ interface IChallengeTitleProps {
   title: string;
   remainingDays: number;
   participants: number;
-  profileImages: string | null;
+  profileImages: string[];
   startDate: string;
   isBeforeStartDate: boolean;
 }
@@ -34,21 +34,17 @@ const ChallengeTitle = ({
       </div>
       <div className="flex items-center px-3 space-x-2 border-2 h-11 rounded-2xl border-habit-gray">
         <div className="flex -space-x-2">
-          <Image
-            src={defaultProfileImage}
-            className="z-30 rounded-full size-9 "
-            alt="defaultProfileImageture of attendees"
-          />
-          <Image
-            src={defaultProfileImage}
-            className="z-20 rounded-full size-9"
-            alt="defaultProfileImageture of attendees"
-          />
-          <Image
-            src={defaultProfileImage}
-            className="z-10 rounded-full size-9 "
-            alt="defaultProfileImageture of attendees"
-          />
+          {profileImages.map((profileImage) => {
+            return (
+              <Image
+                src={profileImage || defaultProfileImage}
+                className="z-30 rounded-full size-9 "
+                alt="profile image"
+                width={36}
+                height={36}
+              />
+            );
+          })}
         </div>
         <div>{participants}</div>
       </div>

--- a/src/app/challenges/[id]/main/page.tsx
+++ b/src/app/challenges/[id]/main/page.tsx
@@ -15,7 +15,8 @@ import { useChallengeDetails } from "@/hooks/useChallengeDetails";
 import Enrollment from "../components/enrollment";
 import { usePathname } from "next/navigation";
 import { getParentPath } from "@/libs/utils";
-import PostsFeed, { PostsFeedExample } from "@/app/components/postsFeed";
+import PostsFeed from "@/app/components/postsFeed";
+import { IChallengeDetailsDto } from "@/types/challenge";
 
 const Page = ({ params: { id } }: { params: { id: string } }) => {
   const { challengeDetails, isLoading, error } = useChallengeDetails(id);
@@ -27,10 +28,15 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
   if (challengeDetails === null) return <div>Challenge not found</div>;
 
   const {
+    title,
+    description,
     startDate,
+    endDate,
+    numberOfParticipants,
+    enrolledMembersProfileImageList,
+    isHost,
     isMemberEnrolledInChallenge,
-  }: { startDate: string; isMemberEnrolledInChallenge: boolean } =
-    challengeDetails;
+  }: IChallengeDetailsDto = challengeDetails;
   const isBeforeStartDate = isBefore(new Date(), new Date(startDate));
 
   // PostsFeed의 prop으로 주기위한 예시. 백엔드완성되면 삭제
@@ -65,26 +71,19 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
       <div className="flex flex-col divide-y-2">
         <div className="flex flex-col px-6">
           <Menu currentPage="챌린지 메인" challengeId={id} />
-          {challengeDetails && (
-            <ChallengeTitle
-              title={challengeDetails.title}
-              startDate={startDate}
-              isBeforeStartDate={isBeforeStartDate}
-              remainingDays={
-                differenceInDays(
-                  new Date(challengeDetails.endDate),
-                  Date.now()
-                ) + 1
-              }
-              participants={42}
-              profileImages={challengeDetails.hostProfileImage}
-            />
-          )}
+          <ChallengeTitle
+            title={title}
+            startDate={startDate}
+            isBeforeStartDate={isBeforeStartDate}
+            remainingDays={differenceInDays(new Date(endDate), Date.now()) + 1}
+            participants={numberOfParticipants}
+            profileImages={enrolledMembersProfileImageList}
+          />
 
           <div className="flex flex-col mt-3 space-y-2 text-sm">
             <div className="flex items-center justify-between h-8">
               <div>챌린지 설명</div>
-              {challengeDetails && challengeDetails.isHost && (
+              {isHost && (
                 <Link
                   href={`/challenges/${id}/edit`}
                   className="flex items-center space-x-1 bg-[#FFF9C4] pl-2 pr-3 py-1 rounded-2xl"
@@ -113,7 +112,7 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
               )}
             </div>
             <div className="px-3 py-2 bg-white rounded-2xl">
-              {challengeDetails && challengeDetails.description}
+              {description}
             </div>
           </div>
           <div className="flex flex-col mt-5 space-y-3">

--- a/src/hooks/useChallengeDetails.ts
+++ b/src/hooks/useChallengeDetails.ts
@@ -1,9 +1,6 @@
 import { useState, useEffect } from "react";
 
-import {
-  IChallengeDetailsDto,
-  challengeDetailsDtoExample,
-} from "@/types/challenge";
+import { IChallengeDetailsDto } from "@/types/challenge";
 import { SelectedStatus } from "@/types/enums";
 import { fetchChallengeDetails } from "../api/challenge";
 

--- a/src/types/challenge/challengeDetails.interface.ts
+++ b/src/types/challenge/challengeDetails.interface.ts
@@ -3,23 +3,12 @@ export interface IChallengeDetailsDto {
   description: string;
   startDate: string;
   endDate: string;
+  numberOfParticipants: number;
   participatingDays: number;
   feePerAbsence: number;
+  isPaidAll: boolean;
   hostNickname: string;
-  hostProfileImage: string | null;
+  enrolledMembersProfileImageList: string[];
   isHost: boolean;
   isMemberEnrolledInChallenge: boolean;
 }
-
-export const challengeDetailsDtoExample = {
-  title: "string",
-  description: "string",
-  startDate: "string",
-  endDate: "string",
-  participatingDays: 42,
-  feePerAbsence: 42,
-  hostNickname: "string",
-  hostProfileImage: null,
-  isHost: true,
-  isMemberEnrolledInChallenge: true,
-};


### PR DESCRIPTION
# 작업 개요

`/challenges/[id]/main` 페이지에서 챌린지 참여자 최대 3명의 프로필 이미지를 표시했습니다. 

아래의 사진에서 주황색으로 표시된 부분에 해당합니다. 

<img width="582" alt="image" src="https://github.com/user-attachments/assets/7afe6e15-1273-4877-b99f-36a70a06ab1d">
