### PR TITLE
Feat/only host can see the button refresh acceess token#73

### DIFF
--- a/src/api/apiManager.ts
+++ b/src/api/apiManager.ts
@@ -21,6 +21,7 @@ const getTokenType = () => {
 const apiManager: AxiosInstance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/api`,
   timeout: 3000,
+  withCredentials: true,
 });
 
 apiManager.interceptors.request.use(
@@ -70,7 +71,7 @@ apiManager.interceptors.response.use(
           "/token"
         );
         if (tokenRefreshResult.status === 200) {
-          const { accessToken } = tokenRefreshResult.data;
+          const { accessToken } = tokenRefreshResult.data.data;
           sessionStorage.setItem("accessToken", accessToken);
           originalRequest.headers.Authorization = `Bearer ${accessToken}`;
           return apiManager(originalRequest);
@@ -81,6 +82,8 @@ apiManager.interceptors.response.use(
         console.log(e);
         logout();
       }
+      // access token이 invalid할때와, expired되었을 때 두 가지 경우로 나눈경우
+      // 지금 코드는 두개 다 같은 상황으로 보고 토큰 재발급받음.
       // if (data.message === "Invalid token") {
       //   logout();
       // } else if (data.message === "TokenExpired") {
@@ -89,7 +92,7 @@ apiManager.interceptors.response.use(
       //       "/token"
       //     );
       //     if (tokenRefreshResult.status === 200) {
-      //       const { accessToken } = tokenRefreshResult.data;
+      //       const { accessToken } = tokenRefreshResult.data.data;
       //       sessionStorage.setItem("accessToken", accessToken);
       //       originalRequest.headers.Authorization = `Bearer ${accessToken}`;
       //       return apiManager(originalRequest);


### PR DESCRIPTION
```
const apiManager: AxiosInstance = axios.create({
  baseURL: `${process.env.NEXT_PUBLIC_BACKEND_SERVER}/api`,
  timeout: 3000,
  withCredentials: true,
});
```
withCredentials옵션을 활성화 시켜야 쿠키를 백엔드에 같이 보냅니다.

```
 if (status === 401) {
      try {
        const tokenRefreshResult: AxiosResponse = await apiManager.post(
          "/token"
        );
        if (tokenRefreshResult.status === 200) {
          const { accessToken } = tokenRefreshResult.data.data;
          sessionStorage.setItem("accessToken", accessToken);
          originalRequest.headers.Authorization = `Bearer ${accessToken}`;
          return apiManager(originalRequest);
        } else {
          logout();
        }
      } 
```
토큰을 리프레쉬 하고 재요청을 보낼 때, tokenRefreshResult.data에서 accessToken을 가져오는것이아니라,
tokenRefreshResult.data.data에서 가져와야함