### PR TITLE
✨ feat: Google Analytics 추가 #82

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hello-pangea/dnd": "^16.6.0",
+        "@next/third-parties": "^14.2.13",
         "@types/react-date-range": "^1.4.9",
         "@types/react-slick": "^0.23.13",
         "ajv": "^8.17.1",
@@ -1038,6 +1039,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "14.2.13",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.2.13.tgz",
+      "integrity": "sha512-OSqD2E9JO0/GE8HT5QAUsYVXwjWtPLScAX70kO2xopwDAdRzakrsQS55Cihd862X/4bUB37ApVZ9DlHcExzeOg==",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6977,6 +6990,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hello-pangea/dnd": "^16.6.0",
+    "@next/third-parties": "^14.2.13",
     "@types/react-date-range": "^1.4.9",
     "@types/react-slick": "^0.23.13",
     "ajv": "^8.17.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+
+import { GoogleAnalytics } from "@next/third-parties/google";
+
 import "./globals.css";
 import RecoilRootWrapper from "./components/recoilWrapper";
 import ToastPopup from "./components/toastPopup";
@@ -27,6 +30,7 @@ export default function RootLayout({
 
         <div id="modal-root"></div>
       </body>
+      <GoogleAnalytics gaId="G-MRGR1YH5MK" />
     </html>
   );
 }


### PR DESCRIPTION
# 개요

방문자 통계 확인을 위해 Google Analytics 를 추가했습니다.

# 상세 작업 내용

## GA 설치

Next.js 14 버전 공식문서([링크](https://nextjs.org/docs/app/building-your-application/optimizing/third-party-libraries#google-analytics))에 따르면, `@next/third-parties` 라이브러리를 이용하면 간단하게 GA 를 설치할 수 있다고 안내하고 있습니다.

GA 는 habitpay 구글 공용 계정에 생성해두었습니다.