### PR TITLE
fix: post 페이지 임시 더미 데이터 생성 #89

### DIFF
--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -2,7 +2,18 @@
 
 import Frame from "@/app/components/frame";
 import PostItem from "@/app/components/postItem";
-import { PostsFeedExample } from "@/app/components/postsFeed";
+// import { PostsFeedExample } from "@/app/components/postsFeed";
+import { ContentDTO } from "@/types/challenge";
+
+const postFeedExample: ContentDTO = {
+  id: 1,
+  challengeEnrollmentId: 1,
+  content: "content",
+  writer: "writer",
+  isAnnouncement: false,
+  createdAt: "2021-09-01",
+  photoViewList: [],
+};
 
 const Page = () => {
   return (
@@ -17,7 +28,7 @@ const Page = () => {
             <div>삭제</div>
             <div className="ml-auto">목록</div>
           </div>
-          <PostItem {...PostsFeedExample[0]} />
+          <PostItem {...postFeedExample} />
         </div>
       </div>
     </Frame>


### PR DESCRIPTION
`posts/[id]/page.tsx` 파일에서  `PostItem` 컴포넌트의 props 로 전달하는 데이터가 존재하지 않아 빌드 실패 및 배포 실패로 이어졌습니다.

해당 문제를 수정하기 위해 임시로 데이터를 생성했는데, 정상적으로 작동할 수 있도록 수정 부탁드립니다.