### PR TITLE
💄 design: 구글 로그인 버튼 디자인 변경 #97

### DIFF
--- a/src/app/components/customButton.tsx
+++ b/src/app/components/customButton.tsx
@@ -1,3 +1,10 @@
+import { Roboto } from "next/font/google";
+
+const roboto = Roboto({
+  subsets: ["latin"],
+  weight: ["500"],
+});
+
 interface ICustomButton {
   onClick: () => void;
 }
@@ -6,7 +13,7 @@ const CustomButton = ({ onClick }: ICustomButton) => {
   return (
     <button
       onClick={onClick}
-      className="flex w-full justify-center items-center rounded-md bg-white px-4 py-2 text-sm font-semibold leading-6 text-neutral-500 border border-neutral-300 shadow-sm hover:bg-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+      className={`flex w-full justify-center items-center rounded-md bg-white px-4 py-2 text-sm font-semibold leading-6 text-neutral-500 border border-neutral-300 shadow-sm hover:bg-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 ${roboto.className}`}
     >
       <svg
         className="mr-2 h-5 w-5"
@@ -32,7 +39,7 @@ const CustomButton = ({ onClick }: ICustomButton) => {
           d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571c0.001-0.001,0.002-0.001,0.003-0.002l6.19,5.238C36.971,39.205,44,34,44,24C44,22.659,43.862,21.35,43.611,20.083z"
         ></path>
       </svg>
-      Sign in with Google
+      <span>Sign in with Google</span>
     </button>
   );
 };

--- a/src/app/components/customButton.tsx
+++ b/src/app/components/customButton.tsx
@@ -6,8 +6,32 @@ const CustomButton = ({ onClick }: ICustomButton) => {
   return (
     <button
       onClick={onClick}
-      className="flex w-full justify-center rounded-md bg-slate-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-slate-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+      className="flex w-full justify-center items-center rounded-md bg-white px-4 py-2 text-sm font-semibold leading-6 text-neutral-500 border border-neutral-300 shadow-sm hover:bg-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
     >
+      <svg
+        className="mr-2 h-5 w-5"
+        xmlns="http://www.w3.org/2000/svg"
+        x="0px"
+        y="0px"
+        viewBox="0 0 48 48"
+      >
+        <path
+          fill="#FFC107"
+          d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"
+        ></path>
+        <path
+          fill="#FF3D00"
+          d="M6.306,14.691l6.571,4.819C14.655,15.108,18.961,12,24,12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C16.318,4,9.656,8.337,6.306,14.691z"
+        ></path>
+        <path
+          fill="#4CAF50"
+          d="M24,44c5.166,0,9.86-1.977,13.409-5.192l-6.19-5.238C29.211,35.091,26.715,36,24,36c-5.202,0-9.619-3.317-11.283-7.946l-6.522,5.025C9.505,39.556,16.227,44,24,44z"
+        ></path>
+        <path
+          fill="#1976D2"
+          d="M43.611,20.083H42V20H24v8h11.303c-0.792,2.237-2.231,4.166-4.087,5.571c0.001-0.001,0.002-0.001,0.003-0.002l6.19,5.238C36.971,39.205,44,34,44,24C44,22.659,43.862,21.35,43.611,20.083z"
+        ></path>
+      </svg>
       Sign in with Google
     </button>
   );


### PR DESCRIPTION
# 작업 내용

1. 구글 로고를 svg 태그로 추가했습니다.
2. 버튼 배경 색상 및 텍스트 색상을 변경했습니다.
3. 버튼의 padding 값을 조정했습니다.
4. 버튼 텍스트 폰트를 roboto 로 변경했습니다. 
    - next 에서 기본으로 제공하는 google 폰트를 적용했습니다. 
    ```typescript
    import { Roboto } from "next/font/google";
    
    const roboto = Roboto({
      subsets: ["latin"],
      weight: ["500"],
    });
    ```

# 참고사항

#97 이슈 내용 참고