### PR TITLE
Feat/challenge list page#101

### DIFF
--- a/src/app/challenges/challenge-list/loading.tsx
+++ b/src/app/challenges/challenge-list/loading.tsx
@@ -1,0 +1,62 @@
+import Frame from "@/app/components/frame";
+
+const Loading = () => {
+  return (
+    <Frame>
+      <div className="flex flex-col px-5 animate-pulse">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-col gap-2">
+            <div className="h-6 bg-gray-400 rounded-md w-14" />
+            <div className="w-20 h-4 bg-gray-400 rounded-md" />
+          </div>
+          <div className="bg-gray-400 rounded-full size-16" />
+        </div>
+        <div className="flex flex-col mb-10">
+          <div className="w-32 h-4 mb-2 bg-gray-400 rounded-md" />
+          <h3 className="w-32 mb-5 bg-gray-400 rounded-md h-7" />
+          <div className="flex items-center mb-2 space-x-2">
+            <div className="w-20 px-3 py-1 bg-gray-400 border-2 h-9 rounded-xl" />
+            <div className="w-16 px-3 py-1 bg-gray-400 border-2 h-9 rounded-xl" />
+            <div className="w-20 px-3 py-1 bg-gray-400 border-2 h-9 rounded-xl" />
+          </div>
+          <div className="flex flex-col px-4 py-6 mt-6 space-y-4 bg-white rounded-xl">
+            <div className="flex flex-col space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <div className="flex items-center -space-x-2">
+                    <div className="z-10 rounded-full size-12 bg-slate-400" />
+                    <div className="flex items-center justify-center rounded-full size-12 bg-habit-lightgray"></div>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <div className="w-16 h-4 bg-gray-400 rounded-md" />
+                    <div className="h-4 bg-gray-400 rounded-md w-36" />
+                  </div>
+                </div>
+                <div className="w-6 h-6" />
+              </div>
+              <div className="w-full h-3 bg-gray-400" />
+            </div>
+            <div className="w-full h-[2px]  bg-habit-lightgray" />
+            <div className="flex flex-col space-y-1">
+              <div className="flex items-center space-x-2 text-sm">
+                <div className="w-6 h-6 bg-gray-400 rounded-md" />
+                <div className="h-5 bg-gray-400 rounded-md w-60" />
+              </div>
+              <div className="flex items-center space-x-2 text-sm">
+                <div className="w-6 h-6 bg-gray-400 rounded-md" />
+                <div className="w-32 h-5 bg-gray-400 rounded-md" />
+              </div>
+              <div className="flex items-center space-x-2 text-sm">
+                <div className="w-6 h-6 bg-gray-400 rounded-md" />
+                <div className="h-5 bg-gray-400 rounded-md w-36" />
+              </div>
+            </div>
+            <div className="w-full py-[6px] h-8 text-sm font-thin text-white bg-gray-400 rounded-xl" />
+          </div>
+        </div>
+      </div>
+    </Frame>
+  );
+};
+
+export default Loading;

--- a/src/app/challenges/challenge-list/page.tsx
+++ b/src/app/challenges/challenge-list/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect } from "react";
+import Image from "next/image";
+
+import { format } from "date-fns";
+
+import FloatingButton from "@/app/components/floatingButton";
+import { useMemberProfile } from "@/hooks/useMemberProfile";
+import { useChallengeEnrolledList } from "@/hooks/useChallengeEnrolledList";
+
+// 나중에 삭제
+import defaultProfileImage from "@/public/default-profile.jpg";
+import Loading from "./loading";
+import withAuth from "@/app/components/withAuth";
+import Frame from "@/app/components/frame";
+// import Head from "next/head";
+
+function Page() {
+  // TODO: 다른 hook 들과 겹치지 않도록 컴포넌트 분리하기
+  const { memberProfile, isLoading, error } = useMemberProfile();
+  const { challengeEnrolledList } = useChallengeEnrolledList();
+  useEffect(() => {
+    document.title = "Challenge List | HabitPay";
+  }, []);
+  if (memberProfile === null || challengeEnrolledList === null) {
+    return <Loading />;
+  }
+
+  return (
+    <Frame hasTabBar>
+      <div className="flex flex-col max-w-xl px-5 mx-auto">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-col">
+            <span className="text-gray-400">안녕하세요</span>
+            <h2 className="text-lg font-semibold">{memberProfile.nickname}</h2>
+          </div>
+          <Image
+            className="rounded-full size-16"
+            src={memberProfile.imageUrl || defaultProfileImage}
+            width={64}
+            height={64}
+            alt="Picture of Avatar"
+          />
+        </div>
+        <div className="flex flex-col mb-10">
+          <span className="mb-2 text-sm font-light">
+            {format(new Date(), "yyyy년 MM월 dd일")}
+          </span>
+          <h3 className="mb-5 text-lg font-semibold">챌린지 목록</h3>
+        </div>
+      </div>
+      <FloatingButton href="/challenges/create_challenge">
+        <div className="flex items-center justify-center text-sm">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-4 h-4"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 4.5v15m7.5-7.5h-15"
+            />
+          </svg>
+          <span>챌린지 생성</span>
+        </div>
+      </FloatingButton>
+    </Frame>
+  );
+}
+
+export default withAuth(Page);

--- a/src/app/challenges/challenge-list/page.tsx
+++ b/src/app/challenges/challenge-list/page.tsx
@@ -14,6 +14,7 @@ import defaultProfileImage from "@/public/default-profile.jpg";
 import Loading from "./loading";
 import withAuth from "@/app/components/withAuth";
 import Frame from "@/app/components/frame";
+import ChallengeList from "@/app/components/challengeList";
 // import Head from "next/head";
 
 function Page() {
@@ -43,12 +44,13 @@ function Page() {
             alt="Picture of Avatar"
           />
         </div>
-        <div className="flex flex-col mb-10">
+        <div className="flex flex-col">
           <span className="mb-2 text-sm font-light">
             {format(new Date(), "yyyy년 MM월 dd일")}
           </span>
           <h3 className="mb-5 text-lg font-semibold">챌린지 목록</h3>
         </div>
+        <ChallengeList />
       </div>
       <FloatingButton href="/challenges/create_challenge">
         <div className="flex items-center justify-center text-sm">

--- a/src/app/components/challengeList.tsx
+++ b/src/app/components/challengeList.tsx
@@ -1,0 +1,102 @@
+import { ChallengeListResponseDTO } from "@/types/challenge";
+import { useEffect, useRef, useState } from "react";
+import apiManager from "@/api/apiManager";
+import { useInfiniteQuery } from "react-query";
+import { AxiosError } from "axios";
+import PostItem from "./postItem";
+import { OnIntersect, useObserver } from "@/hooks/useObserver";
+import Image from "next/image";
+import { format } from "date-fns";
+import Link from "next/link";
+
+export default function ChallengeList() {
+  const bottom = useRef<HTMLDivElement | null>(null);
+  const getChallengeList = async ({
+    pageParam = 0,
+  }: {
+    pageParam?: number;
+  }): Promise<ChallengeListResponseDTO> => {
+    const res = await apiManager.get(`/challenges`, {
+      params: {
+        page: pageParam,
+      },
+    });
+    console.log("res:", res.data.data);
+    return res.data.data;
+  };
+  getChallengeList({ pageParam: 0 });
+
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    status,
+  } = useInfiniteQuery<ChallengeListResponseDTO, AxiosError>(
+    "challengeList",
+    getChallengeList,
+    {
+      getNextPageParam: (lastPage) => {
+        if (lastPage.hasNextPage === true) {
+          console.log("it is not last page");
+          return lastPage.page + 1;
+        }
+        return undefined;
+      },
+    }
+  );
+
+  const onIntersect: OnIntersect = ([entry]) =>
+    entry.isIntersecting && fetchNextPage();
+
+  useObserver({ target: bottom, onIntersect });
+
+  return (
+    <div className="flex flex-col w-full pb-4">
+      {status === "loading" && <p>불러오는 중</p>}
+      {status === "error" && <p>{error?.message}</p>}
+      {status === "success" &&
+        data?.pages.map((challenges, index) => (
+          <div key={index} className="flex flex-col gap-3">
+            {challenges.size > 0 &&
+              challenges.content.map((challenge, index) => (
+                <Link
+                  href={`/challenges/${challenge.id}/main`}
+                  key={index}
+                  className="flex flex-col bg-white rounded-xl py-2 px-3"
+                >
+                  <div className="flex justify-between">
+                    <div className=" text-2xl font-semibold">
+                      {challenge.title}
+                    </div>
+                    <div className="flex items-center gap-1 font-light text-sm">
+                      <div>{challenge.hostNickname}</div>
+                      <Image
+                        src={challenge.hostProfileImage}
+                        alt="ProfileImage of host"
+                        className="rounded-full size-7"
+                        width={7}
+                        height={7}
+                      />
+                    </div>
+                  </div>
+                  <div className="text-sm">
+                    {`챌린지 기간:${format(
+                      new Date(challenge.startDate),
+                      "yy.MM.dd"
+                    )} ~ ${format(new Date(challenge.endDate), "yy.MM.dd")}`}
+                  </div>
+
+                  <div className="text-sm">{`현재 참여인원: ${challenge.numberOfParticipants}`}</div>
+                  <div className="text-sm">{`총 기간(일): ${challenge.participatingDays}`}</div>
+                </Link>
+              ))}
+          </div>
+        ))}
+      <div ref={bottom} />
+      {isFetchingNextPage && <p>계속 불러오는 중</p>}
+    </div>
+  );
+}

--- a/src/app/components/challengeList.tsx
+++ b/src/app/components/challengeList.tsx
@@ -65,10 +65,10 @@ export default function ChallengeList() {
                 <Link
                   href={`/challenges/${challenge.id}/main`}
                   key={index}
-                  className="flex flex-col bg-white rounded-xl py-2 px-3"
+                  className="flex flex-col bg-white rounded-xl py-3 px-3"
                 >
-                  <div className="flex justify-between">
-                    <div className=" text-2xl font-semibold">
+                  <div className="flex justify-between items-center mb-2">
+                    <div className=" text-xl font-semibold">
                       {challenge.title}
                     </div>
                     <div className="flex items-center gap-1 font-light text-sm">

--- a/src/app/components/frame.tsx
+++ b/src/app/components/frame.tsx
@@ -98,7 +98,7 @@ const Frame = ({
               </svg>
             </div>
           </Link>
-          <Link href="/notice">
+          <Link href="/challenges/challenge-list">
             <div
               className={addClassNames(
                 "flex flex-col items-center space-y-2 p-3",
@@ -118,7 +118,7 @@ const Frame = ({
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
+                  d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5"
                 />
               </svg>
             </div>

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import Frame from "@/app/components/frame";
 import PostItem from "@/app/components/postItem";
-// import { PostsFeedExample } from "@/app/components/postsFeed";
 import { ContentDTO } from "@/types/challenge";
 
 const postFeedExample: ContentDTO = {

--- a/src/types/challenge/challengeListResponse.interface.ts
+++ b/src/types/challenge/challengeListResponse.interface.ts
@@ -1,0 +1,24 @@
+// Challenge Content Interface
+export interface ChallengeListContentDTO {
+  id: number;
+  title: string;
+  startDate: string;
+  endDate: string;
+  stopDate: string | null;
+  numberOfParticipants: number;
+  participatingDays: number;
+  isStarted: boolean;
+  isEnded: boolean;
+  hostNickname: string;
+  hostProfileImage: string;
+}
+
+// Pagination Data Interface
+export interface ChallengeListResponseDTO {
+  content: ChallengeListContentDTO[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNextPage: boolean;
+}

--- a/src/types/challenge/index.ts
+++ b/src/types/challenge/index.ts
@@ -4,3 +4,4 @@ export * from "./challengeEnrolledListItem.interface";
 export * from "./challengePatchDto.interface";
 export * from "./challengeContentResponse.interface";
 export * from "./challengeFeeList.interface";
+export * from "./challengeListResponse.interface";


### PR DESCRIPTION
challenge list페이지를 생성하였습니다.
기존 탭바의 알람 이모티콘을 목록 모양으로 수정하였으며 챌린지 리스트로 연결됩니다.

challenge-list페이지는 challengeList컴포넌트를 포함합니다.
챌린지의 목록은 기존의 사용하던 infinite scroll로 우선 구현해두었습니다. 
페이지네이션은 한번에 20개의 챌린지를 불러오도록 되어있는데, 

제가 임의대로 우선 레이아웃을 잡아 놓았습니다. 아래의 그림과같습니다.
![스크린샷 2024-09-25 02 51 02](https://github.com/user-attachments/assets/2cf71df7-21b9-481e-964b-ef2158dfaa1a)
내일 수요지식회가 있어서 이렇게 만들어 두었지만, 레이아웃을 더 바꿔볼 예정이며
infinite scroll이 아닌 페이지를 넘기는 방식으로 바꿀 예정입니다.


challenge list에 대한 api dto
src/types/challenge/challengeListResponse.interface.ts에 작성하였습니다.