### PR TITLE
✨ feat: 챌린지 목록 조회 시 호스트 프로필 기본 이미지 추가

### DIFF
--- a/src/app/components/challengeList.tsx
+++ b/src/app/components/challengeList.tsx
@@ -1,13 +1,16 @@
-import { ChallengeListResponseDTO } from "@/types/challenge";
 import { useEffect, useRef, useState } from "react";
-import apiManager from "@/api/apiManager";
+import Image from "next/image";
+import Link from "next/link";
+
+import { format } from "date-fns";
 import { useInfiniteQuery } from "react-query";
 import { AxiosError } from "axios";
-import PostItem from "./postItem";
+
+import apiManager from "@/api/apiManager";
 import { OnIntersect, useObserver } from "@/hooks/useObserver";
-import Image from "next/image";
-import { format } from "date-fns";
-import Link from "next/link";
+import { ChallengeListResponseDTO } from "@/types/challenge";
+import PostItem from "./postItem";
+import defaultProfileImage from "@/public/default-profile.jpg";
 
 export default function ChallengeList() {
   const bottom = useRef<HTMLDivElement | null>(null);
@@ -74,7 +77,7 @@ export default function ChallengeList() {
                     <div className="flex items-center gap-1 font-light text-sm">
                       <div>{challenge.hostNickname}</div>
                       <Image
-                        src={challenge.hostProfileImage}
+                        src={challenge.hostProfileImage || defaultProfileImage}
                         alt="ProfileImage of host"
                         className="rounded-full size-7"
                         width={7}


### PR DESCRIPTION
챌린지 목록 조회 페이지에서 호스트의 프로필 이미지가 없는 경우 기본 프로필 이미지를 보여줍니다.