### PR TITLE
Fix/participation page,modals#107

### DIFF
--- a/src/app/challenges/[id]/components/isCompleteToday.tsx
+++ b/src/app/challenges/[id]/components/isCompleteToday.tsx
@@ -1,18 +1,24 @@
 interface IIsCompleteTodayProps {
-  complete: boolean;
+  isParticipatedToday: boolean;
+  isTodayParticipatingDay: boolean;
 }
 
-const IsCompleteToday = ({ complete }: IIsCompleteTodayProps) => {
-  return complete ? (
+const IsCompleteToday = ({
+  isParticipatedToday,
+  isTodayParticipatingDay,
+}: IIsCompleteTodayProps) => {
+  return isParticipatedToday === true ? (
     <span className="mt-5 text-center text-habit-green">
       오늘은 챌린지에 참여완료 하셨습니다.
     </span>
-  ) : (
+  ) : isTodayParticipatingDay === true ? (
     <span className="mt-5 text-sm text-center text-red-600">
       오늘은 챌린지에 참여하지 않으셨습니다!
       <br />
       챌린지 인증 글을 작성해주세요.
     </span>
+  ) : (
+    <span className="mt-5 text-center ">오늘은 챌린지 참여날이 아닙니다.</span>
   );
 };
 

--- a/src/app/challenges/[id]/main/page.tsx
+++ b/src/app/challenges/[id]/main/page.tsx
@@ -245,7 +245,10 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
                 벌금 현황 보기
               </Link>
             </div>
-            <IsCompleteToday complete={false} />
+            <IsCompleteToday
+              isParticipatedToday={challengeDetails.isParticipatedToday}
+              isTodayParticipatingDay={challengeDetails.isTodayParticipatingDay}
+            />
           </div>
         </div>
         <div className="flex flex-col px-6 pt-4">

--- a/src/app/challenges/[id]/participation/page.tsx
+++ b/src/app/challenges/[id]/participation/page.tsx
@@ -94,7 +94,10 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
             participants={numberOfParticipants}
             profileImages={enrolledMembersProfileImageList}
           />
-          <IsCompleteToday complete={false} />
+          <IsCompleteToday
+            isParticipatedToday={challengeDetails.isParticipatedToday}
+            isTodayParticipatingDay={challengeDetails.isTodayParticipatingDay}
+          />
         </div>
         <div className="flex flex-col px-6 py-6 ">
           <Calendar

--- a/src/app/challenges/my-challenge/components/challengeCard.tsx
+++ b/src/app/challenges/my-challenge/components/challengeCard.tsx
@@ -16,7 +16,9 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
   return (
     <>
       {items.map((item, index) => {
-        let progressPercent: number = Math.round(0 / 0) * 100;
+        let progressPercent: number =
+          Math.round(item.successCount / item.totalParticipatingDaysCount) *
+          100;
         if (isNaN(progressPercent) || !isFinite(progressPercent)) {
           progressPercent = 100;
         }

--- a/src/app/challenges/my-challenge/components/challengeCard.tsx
+++ b/src/app/challenges/my-challenge/components/challengeCard.tsx
@@ -18,7 +18,8 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
     <>
       {items.map((item, index) => {
         const progressPercent: number =
-          (item.successCount / item.totalParticipatingDaysCount) * 100;
+          Math.round(item.successCount / item.totalParticipatingDaysCount) *
+          100;
 
         return (
           <div
@@ -62,7 +63,7 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
                         )}
                     </div>
                   </div>
-                  
+
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"

--- a/src/app/challenges/my-challenge/components/challengeCard.tsx
+++ b/src/app/challenges/my-challenge/components/challengeCard.tsx
@@ -16,10 +16,10 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
   return (
     <>
       {items.map((item, index) => {
-        const progressPercent: number =
-          Math.round(item.successCount / item.totalParticipatingDaysCount) *
-          100;
-
+        let progressPercent: number = Math.round(0 / 0) * 100;
+        if (isNaN(progressPercent) || !isFinite(progressPercent)) {
+          progressPercent = 100;
+        }
         return (
           <div
             key={index}
@@ -171,7 +171,7 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
             {challengeState == ChallengeStatesEnum.InProgress &&
               item.isTodayParticipatingDay &&
               item.isParticipatedToday && (
-                <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-green rounded-xl">
+                <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-gray  rounded-xl">
                   이미 참여했습니다.
                 </button>
               )}
@@ -179,9 +179,12 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
             {challengeState == ChallengeStatesEnum.InProgress &&
               item.isTodayParticipatingDay &&
               !item.isParticipatedToday && (
-                <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-green rounded-xl">
+                <Link
+                  href={`/challenges/${item.challengeId}/post`}
+                  className="w-full py-[6px] text-sm font-thin text-center text-white bg-habit-green rounded-xl"
+                >
                   참여하기
-                </button>
+                </Link>
               )}
 
             {challengeState == ChallengeStatesEnum.InProgress &&

--- a/src/app/components/postItem.tsx
+++ b/src/app/components/postItem.tsx
@@ -21,6 +21,7 @@ const PostItem = ({
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
+    infinite: false,
   };
   return (
     <div className="flex flex-col px-5 py-5 bg-white rounded-2xl">

--- a/src/app/components/toastPopup.tsx
+++ b/src/app/components/toastPopup.tsx
@@ -28,7 +28,7 @@ export default function ToastPopup() {
   return (
     <div className="flex justify-center w-full">
       <div
-        className={`fixed z-50 flex px-4 py-3 w-11/12 max-w-md items-center gap-5 rounded-xl shadow-[0px_2px_8px_rgba(0,0,0,0.25)] transition-opacity duration-500 ${
+        className={`fixed z-50 flex px-4 py-3 w-11/12 max-w-md items-center gap-5 rounded-xl shadow-[0px_2px_8px_rgba(0,0,0,0.25)] transition-opacity duration-500 pointer-events-none ${
           toastPopup.top ? "top-12" : "bottom-24"
         } ${toastPopup.success ? "bg-green-400" : "bg-red-400"} ${
           isVisible ? "opacity-100" : "opacity-0"

--- a/src/app/test_page/page.tsx
+++ b/src/app/test_page/page.tsx
@@ -3,6 +3,7 @@
 import { NextPage } from "next";
 import { useEffect, useState } from "react";
 import ConfirmModal from "../components/confirmModal";
+import Calendar from "react-calendar";
 
 const Page: NextPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -14,15 +15,7 @@ const Page: NextPage = () => {
   };
   return (
     <div>
-      <span>def</span>
-      <span>ghi</span>
-      <ConfirmModal
-        onClick={onClick}
-        open={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-      >
-        삭제
-      </ConfirmModal>
+      <Calendar />
     </div>
   );
 };

--- a/src/hooks/useChallengeDetails.ts
+++ b/src/hooks/useChallengeDetails.ts
@@ -27,8 +27,8 @@ export const useChallengeDetails = (id: string) => {
     const fetchData = async () => {
       try {
         const data = await fetchChallengeDetails(id);
-
         if (data) {
+          console.log(data);
           setChallengeDetails(data);
           setSelectedDays(
             calculateSelectedDays(selectedDays, data.participatingDays)

--- a/src/styles/CustomCalendar.css
+++ b/src/styles/CustomCalendar.css
@@ -1,0 +1,184 @@
+.react-calendar {
+  width: 350px;
+  max-width: 100%;
+  background: white;
+  border: 1px solid #a0a096;
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.125em;
+}
+
+.react-calendar--doubleView {
+  width: 700px;
+}
+
+.react-calendar--doubleView .react-calendar__viewContainer {
+  display: flex;
+  margin: -0.5em;
+}
+
+.react-calendar--doubleView .react-calendar__viewContainer > * {
+  width: 50%;
+  margin: 0.5em;
+}
+
+.react-calendar,
+.react-calendar *,
+.react-calendar *:before,
+.react-calendar *:after {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.react-calendar button {
+  margin: 0;
+  border: 0;
+  outline: none;
+}
+
+.react-calendar button:enabled:hover {
+  cursor: pointer;
+}
+
+.react-calendar__navigation {
+  display: flex;
+  height: 44px;
+  margin-bottom: 1em;
+}
+
+.react-calendar__navigation button {
+  min-width: 44px;
+  background: none;
+}
+
+.react-calendar__navigation button:disabled {
+  background-color: #f0f0f0;
+}
+
+.react-calendar__navigation button:enabled:hover,
+.react-calendar__navigation button:enabled:focus {
+  background-color: #e6e6e6;
+}
+
+.react-calendar__month-view__weekdays {
+  text-align: center;
+  text-transform: uppercase;
+  font: inherit;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+
+.react-calendar__month-view__weekdays__weekday {
+  padding: 0.5em;
+}
+
+.react-calendar__month-view__weekNumbers .react-calendar__tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: inherit;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+
+.react-calendar__month-view__days__day--weekend:nth-child(7n) {
+  color: #d10000;
+}
+
+.react-calendar__month-view__days__day--neighboringMonth,
+.react-calendar__decade-view__years__year--neighboringDecade,
+.react-calendar__century-view__decades__decade--neighboringCentury {
+  color: #757575;
+}
+
+.react-calendar__year-view .react-calendar__tile,
+.react-calendar__decade-view .react-calendar__tile,
+.react-calendar__century-view .react-calendar__tile {
+  padding: 2em 0.5em;
+}
+
+.react-calendar__tile {
+  height: 45px;
+  max-width: 100%;
+  padding: 10px 6.6667px;
+  background: none;
+  text-align: center;
+  line-height: 16px;
+  font: inherit;
+  font-size: 0.833em;
+}
+
+.react-calendar__tile:disabled {
+  background-color: #f0f0f0;
+  color: #ababab;
+}
+
+.react-calendar__month-view__days__day--neighboringMonth:disabled,
+.react-calendar__decade-view__years__year--neighboringDecade:disabled,
+.react-calendar__century-view__decades__decade--neighboringCentury:disabled {
+  color: #cdcdcd;
+}
+
+.react-calendar__tile:enabled:hover,
+.react-calendar__tile:enabled:focus {
+  background-color: #e6e6e6;
+}
+
+.react-calendar__tile--now {
+  background: #ffff76;
+}
+
+.react-calendar__tile--now:enabled:hover,
+.react-calendar__tile--now:enabled:focus {
+  background: #ffffa9;
+}
+
+.react-calendar__tile--hasActive {
+  background: #76baff;
+}
+
+.react-calendar__tile--hasActive:enabled:hover,
+.react-calendar__tile--hasActive:enabled:focus {
+  background: #a9d4ff;
+}
+
+.react-calendar__tile--active {
+  background: #006edc;
+  color: white;
+}
+
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #1087ff;
+}
+
+.react-calendar--selectRange .react-calendar__tile--hover {
+  background-color: #e6e6e6;
+}
+
+.dot-success {
+  height: 8px;
+  width: 8px;
+  background-color: #96da99;
+  border-radius: 50%;
+  display: flex;
+  margin-left: 10px;
+}
+
+.dot-failure {
+  height: 8px;
+  width: 8px;
+  background-color: #f87171;
+  border-radius: 50%;
+  display: flex;
+  margin-left: 10px;
+}
+
+.dot-none {
+  height: 8px;
+  width: 8px;
+  /* background-color: #ffffff; */
+  border-radius: 50%;
+  display: flex;
+  margin-left: 1px;
+}

--- a/src/types/challenge/challengeDetails.interface.ts
+++ b/src/types/challenge/challengeDetails.interface.ts
@@ -3,11 +3,14 @@ export interface IChallengeDetailsDto {
   description: string;
   startDate: string;
   endDate: string;
+  stopDate: string;
   numberOfParticipants: number;
   participatingDays: number;
   feePerAbsence: number;
   totalAbsenceFee: number;
   isPaidAll: boolean;
+  isTodayParticipatingDay: boolean;
+  isParticipatedToday: boolean;
   hostNickname: string;
   enrolledMembersProfileImageList: string[];
   isHost: boolean;

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -7,7 +7,8 @@
       "@/libs/*": ["libs/*"],
       "@/types/*": ["types/*"],
       "@/hooks/*": ["hooks/*"],
-      "@/public/*": ["../public/*"]
+      "@/styles/*": ["styles/*"],
+      "@/public/*": ["../public/*"],
     }
   }
 }


### PR DESCRIPTION
모달이 다른 요소를 가리는 문제는 tailwind에 pointer-events-none 속성을 줌으로써 방지하였습니다.

![스크린샷 2024-10-18 18 41 45](https://github.com/user-attachments/assets/53e21728-be9f-4db0-91cf-a9280bb7efeb)
참여기록 페이지의 css를 수정하였습니다.
성공한날은 초록색dot, 실패한 날은 붉은색dot으로 할 수 있도록 만들어두었습니다.
관련 api가 개발되면 바로 연동할 예정입니다.

![스크린샷 2024-10-18 18 45 09](https://github.com/user-attachments/assets/4eb81f11-83a9-4bf6-af27-80e147356f72)
챌린지에 아직 참여하지 않았는지, 챌린지 날이 아닌지, 챌린지를 완료했는지를 표시해주는 곳을 api와 연동하였습니다.

![스크린샷 2024-10-18 18 45 30](https://github.com/user-attachments/assets/167f1bf0-1ffd-4093-a769-704657aa6923)
my-challenge페이지에서 이미 참여했습니다. 오늘은 참여하는 날이 아닙니다. 의 버튼 비활성화를 하였고, 참여가능 시에는 버튼을 누르면 바로 게시물 작성 페이지로 연결되도록 하였습니다.

나의 달성율 예외처리를 하였습니다. 분모가 0일경우 달성율을 0으로 할지 100으로 할 지 고민했는데, 우선 100으로 해두었습니다. 달성해야하는 날이 없으므로 더 맞는 방향이라고 생각했는데, 좋은의견이 있으면 알려주시면 감사하겠습니다. (사실 백엔드에서 1차적으로 막을거라 예외상황이 발생할 확률이 극히 드묾)