### PR TITLE
게시물에 프로필사진 추가, 포스트 작성 후 redirect, 게시물 time stamp업데이트#111

### DIFF
--- a/src/app/challenges/[id]/post/page.tsx
+++ b/src/app/challenges/[id]/post/page.tsx
@@ -122,6 +122,7 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
       });
       const preSignedUrls: string[] = res.data?.data;
       uploadImagesToS3(preSignedUrls, form.photos);
+      router.push(`/challenges/${id}/main`);
     } catch (error) {
       setToastPopup({
         // @ts-ignore

--- a/src/app/components/postItem.tsx
+++ b/src/app/components/postItem.tsx
@@ -7,10 +7,12 @@ import "slick-carousel/slick/slick-theme.css";
 
 import { formatToTimeAgo } from "@/libs/utils";
 import { ContentDTO } from "@/types/challenge";
+import { formatDistanceToNow, parseISO } from "date-fns";
 
 const PostItem = ({
   // profileImage,
   writer,
+  profileUrl,
   createdAt,
   isAnnouncement,
   photoViewList,
@@ -26,13 +28,13 @@ const PostItem = ({
   return (
     <div className="flex flex-col px-5 py-5 bg-white rounded-2xl">
       <div className="flex items-center gap-2 pb-4 border-b-2">
-        {/* <Image
-          src={profileImage}
+        <Image
+          src={profileUrl}
           className="z-30 rounded-full size-12"
           alt="profileImage of writer"
           width={12}
           height={12}
-        /> */}
+        />
         <div className="flex flex-col justify-center gap-1">
           <span className="text-sm font-semibold">{writer}</span>
           <span className="text-sm text-habit-gray">

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -9,6 +9,7 @@ const postFeedExample: ContentDTO = {
   challengeEnrollmentId: 1,
   content: "content",
   writer: "writer",
+  profileUrl: "",
   isAnnouncement: false,
   createdAt: "2021-09-01",
   photoViewList: [],

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -18,11 +18,24 @@ export function getParentPath(pathname: string) {
 
 // 게시물등에서 사용하는 시간 함수. (몇 일 전으로 표기 해줌.)
 export function formatToTimeAgo(date: string): string {
-  const dayInMs = 1000 * 60 * 60 * 24;
+  const SEC = 1000;
+  const MIN = SEC * 60;
+  const HOUR = MIN * 60;
+  const DAY = HOUR * 24;
+
   const time = new Date(date).getTime();
+  const kstTime = new Date(time + 9 * HOUR).getTime();
   const now = new Date().getTime();
-  const diff = Math.round((time - now) / dayInMs);
+  const diff = kstTime - now;
 
   const formatter = new Intl.RelativeTimeFormat("ko");
-  return formatter.format(diff, "days");
+  if (-diff <= MIN) {
+    return formatter.format(Math.round(diff / SEC), "seconds");
+  } else if (-diff <= HOUR) {
+    return formatter.format(Math.round(diff / MIN), "minutes");
+  } else if (-diff <= DAY) {
+    return formatter.format(Math.round(diff / HOUR), "hours");
+  } else {
+    return formatter.format(Math.round(diff / DAY), "days");
+  }
 }

--- a/src/types/challenge/challengeContentResponse.interface.ts
+++ b/src/types/challenge/challengeContentResponse.interface.ts
@@ -11,6 +11,7 @@ export interface ContentDTO {
   challengeEnrollmentId: number;
   content: string;
   writer: string;
+  profileUrl: string;
   isAnnouncement: boolean;
   createdAt: string;
   photoViewList: PhotoViewDTO[];


### PR DESCRIPTION
api가 업데이트 되어 게시물을 올린사람의 프로필 사진이 추가되도록 하였습니다.

포스트 작성 후, 페이지에 머물러 있었으나 챌린지 메인 페이지로 돌아가도록 수정하였습니다.

게시물의 시간표시를 좀 더 보기 좋게 수정하였습니다.
api로 부터 게시물 생성시를 UTC단위로 받게되어 kst로 변환하여 사용합니다.
(게시물 생성 후 1분 미만시 초단위, 1시간 미만 시 분단위, 24시간 미만 시 시간단위, 그 이후 일 단위)
