### PR TITLE
수정완료#115

### DIFF
--- a/src/app/components/postItem.tsx
+++ b/src/app/components/postItem.tsx
@@ -7,6 +7,7 @@ import "slick-carousel/slick/slick-theme.css";
 
 import { formatToTimeAgo } from "@/libs/utils";
 import { ContentDTO } from "@/types/challenge";
+import defaultProfileImage from "@/public/default-profile.jpg";
 
 const PostItem = ({
   writer,
@@ -27,7 +28,7 @@ const PostItem = ({
     <div className="flex flex-col px-5 py-5 bg-white rounded-2xl">
       <div className="flex items-center gap-2 pb-4 border-b-2">
         <Image
-          src={profileUrl}
+          src={profileUrl || defaultProfileImage}
           className="z-30 rounded-full size-12"
           alt="profileImage of writer"
           width={12}

--- a/src/app/components/postsFeed.tsx
+++ b/src/app/components/postsFeed.tsx
@@ -51,7 +51,7 @@ export default function PostsFeed({ id, isAnnouncements }: PostsFeedProps) {
     isFetchingNextPage,
     status,
   } = useInfiniteQuery<ChallengeContentResponseDTO, AxiosError>(
-    "feedPosts",
+    ["feedPosts", id],
     getPosts,
     {
       getNextPageParam: (lastPage) => {


### PR DESCRIPTION
게시물에서 프로필사진이 없는 계정의 경우 기본 프로필사진이 표시되도록 하였습니다.

피드를 표시해주는 postsFeed컴포넌트의 useInfiniteQuery를 불러올때, id를 쿼리키로 갖도록수정하였습니다.