### PR TITLE
[rename] 챌린지 게시물 생성 api 엔드포인트 변경 #119

### DIFF
--- a/src/app/challenges/[id]/post/page.tsx
+++ b/src/app/challenges/[id]/post/page.tsx
@@ -114,7 +114,7 @@ const Page = ({ params: { id } }: { params: { id: string } }) => {
         isAnnouncement: isAnnouncement,
         photos: convertFilesToPhotoDTOs(form.photos),
       };
-      const res = await apiManager.post(`/challenges/${id}/post`, data);
+      const res = await apiManager.post(`/challenges/${id}/posts`, data);
       setToastPopup({
         message: res.data.message,
         top: false,

--- a/src/app/challenges/my-challenge/components/challengeCard.tsx
+++ b/src/app/challenges/my-challenge/components/challengeCard.tsx
@@ -41,7 +41,11 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
                       />
                       <div className="flex items-center justify-center rounded-full size-12 bg-habit-lightgray">
                         <span className="text-lg text-gray-600">
-                          {`+${item.numberOfParticipants - 1}`}
+                          {`+${
+                            item.numberOfParticipants === 0
+                              ? 0
+                              : item.numberOfParticipants - 1
+                          }`}
                         </span>
                       </div>
                     </div>


### PR DESCRIPTION
# 개요

백엔드 챌린지 게시물 생성 API 엔드포인트 변경에 따른 코드를 수정했습니다.

## 1. `POST /challenge/{id}/post` 

단수형 `post`이 아닌 복수형 `posts`로 변경했습니다.

`POST /challenge/{id}/posts` 

```typescript
  const onSubmitWithValidation = async (form: IForm) => {
    try {
      const data: ICreatePostDTO = {
        content: form.content,
        isAnnouncement: isAnnouncement,
        photos: convertFilesToPhotoDTOs(form.photos),
      };
      // 변경한 부분
      const res = await apiManager.post(`/challenges/${id}/posts`, data); 
```

## 2. 챌린지 참여자 0명인 경우 챌린지 참여자 수 표시 문제 수정

백엔드 챌린지 중도 포기 API 구현하다가 발견한 부분이 있어서 이번 PR 에 함께 올립니다.

<img width="592" alt="image" src="https://github.com/user-attachments/assets/3cb71f3e-ca6b-4b4a-8e5f-6b051a1b1a50">

챌린지 총 참여자 수가 0 이 되면 그림과 같이 `+-1` 로 표시되는 현상을 발견했습니다.

이 경우에는 0명으로 표시하기 위해 다음과 같이 코드를 수정했습니다.

```diff

- {`+${item.numberOfParticipants - 1}`}

+ {`+${
+ item.numberOfParticipants === 0
+   ? 0
+   : item.numberOfParticipants - 1
+}`}
```

