### PR TITLE
수정완료#125

### DIFF
--- a/src/app/challenges/my-challenge/components/challengeCard.tsx
+++ b/src/app/challenges/my-challenge/components/challengeCard.tsx
@@ -16,9 +16,9 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
   return (
     <>
       {items.map((item, index) => {
-        let progressPercent: number =
-          Math.round(item.successCount / item.totalParticipatingDaysCount) *
-          100;
+        let progressPercent: number = Math.round(
+          (item.successCount / item.totalParticipatingDaysCount) * 100
+        );
         if (isNaN(progressPercent) || !isFinite(progressPercent)) {
           progressPercent = 100;
         }


### PR DESCRIPTION
```typescript
let progressPercent: number = Math.round(
          (item.successCount / item.totalParticipatingDaysCount) * 100
        );
```
나눈 수 * 100을 한 후 반올림을 해야하는데,
나눈 수를 반올림 한 후 100을 곱해버려서 50퍼 이하일경우 0퍼센트로 표시되었습니다. 수정하였습니다.