### PR TITLE
🐛 fix: 챌린지 게시물 응답 DTO 수정 #131

### DIFF
--- a/src/app/components/postsFeed.tsx
+++ b/src/app/components/postsFeed.tsx
@@ -36,8 +36,8 @@ export default function PostsFeed({ id, isAnnouncements }: PostsFeedProps) {
       getPosts,
       {
         getNextPageParam: (lastPage) => {
-          if (lastPage.last === false) {
-            return lastPage.pageable.pageNumber + 1;
+          if (lastPage.isLast === false) {
+            return lastPage.pageNumber + 1;
           }
           return undefined;
         },

--- a/src/types/challenge/challengeContentResponse.interface.ts
+++ b/src/types/challenge/challengeContentResponse.interface.ts
@@ -37,12 +37,11 @@ export interface PageableDTO {
 // ChallengeContentResponseDTO
 export interface ChallengeContentResponseDTO {
   content: ContentDTO[];
-  pageable: PageableDTO;
+  pageNumber: number;
   size: number;
-  number: number;
-  sort: SortDTO;
-  numberOfElements: number;
-  first: boolean;
-  last: boolean;
-  empty: boolean;
+  isLast: boolean;
+  isFirst: boolean;
+  isEmpty: boolean;
+  hasNextPage: boolean;
+  pageable: PageableDTO;
 }


### PR DESCRIPTION
# 개요

`/challenges/[id]/main` 페이지에서 전체 게시물을 불러오지 못하는 문제를 수정합니다.

# 문제 현상

![iShot_2024-12-05_19 34 50](https://github.com/user-attachments/assets/9fecf79d-9fb4-4398-a89b-ae3c1244da69)

챌린지 메인 페이지에서 스크롤을 내리면 다음 페이지 내용이 나오는 것이 아닌 첫 페이지 내용이 반복해서 표시되었습니다.

# 원인

프론트에서는 `GET /challenges/{id}/posts?page=1`와 같이 page number를 1부터 요청을 하는데, 백엔드에서는 `pageable.pageNumber`의 값이 아래와 같이 0부터 시작합니다.

```json
{
    "message": "",
    "data": {
        "content": [
            {
                "id": 13,
                "challengeId": 6,
                "content": "13",
                "writer": "joonhyeok.han",
                "isPostAuthor": true,
                "profileUrl": "",
                "isAnnouncement": false,
                "createdAt": "2024-12-05T10:23:01.272858",
                "photoViewList": []
            },
        ],
        "pageable": {
            "pageNumber": 0, // 0부터 시작하는 페이지 번호
            "pageSize": 10,
            "sort": {
                "sorted": true,
                "unsorted": false,
                "empty": false
            },
            "offset": 0,
            "paged": true,
            "unpaged": false
        },
        "size": 10,
        "number": 0,
        "sort": {
            "sorted": true,
            "unsorted": false,
            "empty": false
        },
        "first": true,
        "last": false,
        "numberOfElements": 10,
        "empty": false
    }
}
```

프론트에서는 다음 페이지를 요청할 때 `pageable.pageNumber + 1`로 보내는데, 초기값이 0이다보니 `GET /challenges/{id}/posts?page=1` 요청을 계속 보냅니다.
하지만 백엔드에서는 쿼리 파라미터 page의 값이 0이든 1이든 동일하게 첫 페이지가 반환하기 때문에 2페이지부터 정상적으로 불러올 수 없었습니다.

# 작업 내용

## `ChallengeContentResponseDTO` 수정 

백엔드에서 응답으로 보내는 DTO 구조를 변경함에 따라 코드를 수정했습니다.

```typescript
export interface ChallengeContentResponseDTO {
  content: ContentDTO[];
  pageNumber: number;
  size: number;
  isLast: boolean;
  isFirst: boolean;
  isEmpty: boolean;
  hasNextPage: boolean;
  pageable: PageableDTO;
}
```

# 문제 해결 화면

아래의 화면과 같이 정상적으로 모든 게시물을 조회할 수 있게 되었습니다.

![iShot_2024-12-05_19 39 38](https://github.com/user-attachments/assets/a983a5e5-087f-45da-a1f1-583e94bb418a)
