### PR TITLE
[feat] 챌린지 시작 전 참여 및 참여 취소 버튼 로직 수정#134

### DIFF
--- a/src/app/challenges/[challengeId]/components/enrollment.tsx
+++ b/src/app/challenges/[challengeId]/components/enrollment.tsx
@@ -10,9 +10,14 @@ import { toastPopupAtom } from "@/hooks/atoms";
 interface IEnrollmentProps {
   id: string;
   isMemberEnrolledInChallenge: boolean;
+  isHost: boolean;
 }
 
-const Enrollment = ({ id, isMemberEnrolledInChallenge }: IEnrollmentProps) => {
+const Enrollment = ({
+  id,
+  isMemberEnrolledInChallenge,
+  isHost,
+}: IEnrollmentProps) => {
   const [
     isMemberEnrolledInChallengeState,
     setIsMemberEnrolledInChallengeState,
@@ -58,10 +63,13 @@ const Enrollment = ({ id, isMemberEnrolledInChallenge }: IEnrollmentProps) => {
     }
   };
 
+  if (isHost) {
+    return <></>;
+  }
+
   return (
     <>
       {isMemberEnrolledInChallengeState ? (
-        // TODO: 빨간색으로 변경하기
         <Button
           color="red"
           onClick={cancelChallengeEnrollment}

--- a/src/app/challenges/[challengeId]/main/page.tsx
+++ b/src/app/challenges/[challengeId]/main/page.tsx
@@ -281,6 +281,7 @@ const Page = ({
               <Enrollment
                 id={challengeId as string}
                 isMemberEnrolledInChallenge={isMemberEnrolledInChallenge}
+                isHost={isHost}
               />
             ) : (
               <>


### PR DESCRIPTION
# 개요

챌린지 시작 전에 챌린지 메인 페이지(/challenges/[id]/main)에서 챌린지 주최자에게는 챌린지 참여/참여 취소 버튼이 보이지 않도록 합니다.

# 작업 내용

`Enrollment` 컴포넌트에 `isHost`를 props로 전달하여 챌린지 주최자에게는 버튼이 아예 보이지 않도록 구현했습니다.

# 작업 결과물

## 챌린지 주최자 화면
<img width="635" alt="image" src="https://github.com/user-attachments/assets/17e15114-6942-4c4e-94c1-3157bfcb8e7c" />

## 챌린지 참여자 화면
<img width="629" alt="image" src="https://github.com/user-attachments/assets/d62c7501-6acd-4eae-9cdd-227b0dc281af" />


