### PR TITLE
[feat] 이미지 업로드 파일 크기 제한 상향#136

### DIFF
--- a/src/app/challenges/[challengeId]/post/page.tsx
+++ b/src/app/challenges/[challengeId]/post/page.tsx
@@ -1,19 +1,30 @@
 "use client";
 
-import Frame from "@/app/components/frame";
-import { MB, validImageExtensions } from "@/libs/constants";
-import { addClassNames } from "@/libs/utils";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+
 import { useForm } from "react-hook-form";
-import PreviewList from "./components/previewList";
-import apiManager from "@/api/apiManager";
-import { ICreatePostDTO } from "@/types/post";
 import { useSetRecoilState } from "recoil";
+
+import apiManager from "@/api/apiManager";
+import Frame from "@/app/components/frame";
+import {
+  MAX_FILE_SIZE,
+  MB,
+  SUPPORTED_IMAGE_EXTENSIONS,
+} from "@/libs/constants";
+import PreviewList from "./components/previewList";
 import { toastPopupAtom } from "@/hooks/atoms";
-import { useRouter } from "next/navigation";
+import { ICreatePostDTO } from "@/types/post";
 import { IChallengeDetailsDto } from "@/types/challenge";
-import { convertToPhotoDTO, uploadImagesToS3 } from "@/libs/imageUploadUtils";
+import { addClassNames } from "@/libs/utils";
+import {
+  convertToPhotoDTO,
+  uploadImagesToS3,
+  isValidImageSize,
+  isValidImageExtension,
+} from "@/libs/imageUploadUtils";
+import { PopupErrorMessage } from "@/types/enums";
 
 export interface imageInfo {
   file?: File;
@@ -97,25 +108,27 @@ const Page = ({
       });
       return;
     }
-    if (!fileList.every((file) => validImageExtensions.includes(file.type))) {
+
+    if (!fileList.every(isValidImageExtension)) {
       setToastPopup({
-        message: "지원되는 파일 형식은 JPEG, JPG, PNG, GIF입니다.",
+        message: PopupErrorMessage.UnsupportedFileType,
         top: false,
         success: false,
       });
       setError("photos", {
-        message: "지원되는 파일 형식은 JPEG, JPG, PNG, GIF입니다.",
+        message: PopupErrorMessage.UnsupportedFileType,
       });
       return;
     }
-    if (!fileList.every((file) => file.size <= 5 * MB)) {
+
+    if (!fileList.every(isValidImageSize)) {
       setToastPopup({
-        message: "사진 한 장의 크기는 최대 1MB 입니다.",
+        message: PopupErrorMessage.FileSizeExceeded,
         top: false,
         success: false,
       });
       setError("photos", {
-        message: "사진 한 장의 크기는 최대 1MB 입니다.",
+        message: PopupErrorMessage.FileSizeExceeded,
       });
       return;
     }
@@ -191,7 +204,7 @@ const Page = ({
                 <input
                   className="hidden"
                   type="file"
-                  accept={validImageExtensions.join(",")}
+                  accept={SUPPORTED_IMAGE_EXTENSIONS.join(",")}
                   multiple
                   {...register("photos", { onChange: onImageFilesChange })}
                 />

--- a/src/app/challenges/[challengeId]/posts/[postId]/edit/page.tsx
+++ b/src/app/challenges/[challengeId]/posts/[postId]/edit/page.tsx
@@ -1,20 +1,27 @@
 "use client";
 
-import Frame from "@/app/components/frame";
-import { MB, validImageExtensions } from "@/libs/constants";
-import { addClassNames, urlToFileWithAxios } from "@/libs/utils";
-import { usePathname } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+
 import { useForm } from "react-hook-form";
-import PreviewList from "../../../post/components/previewList";
-import apiManager from "@/api/apiManager";
-import { IPatchPostDTO } from "@/types/post";
 import { useSetRecoilState } from "recoil";
+
+import apiManager from "@/api/apiManager";
+import Frame from "@/app/components/frame";
+import { SUPPORTED_IMAGE_EXTENSIONS } from "@/libs/constants";
 import { toastPopupAtom } from "@/hooks/atoms";
-import { useRouter } from "next/navigation";
+import { IPatchPostDTO } from "@/types/post";
 import { ContentDTO } from "@/types/challenge";
-import { convertToPhotoDTO, uploadImagesToS3 } from "@/libs/imageUploadUtils";
+import { addClassNames, urlToFileWithAxios } from "@/libs/utils";
+import {
+  convertToPhotoDTO,
+  isValidImageSize,
+  isValidImageExtension,
+  uploadImagesToS3,
+} from "@/libs/imageUploadUtils";
+import PreviewList from "../../../post/components/previewList";
 import { imageInfo } from "../../../post/page";
+import { PopupErrorMessage } from "@/types/enums";
 
 interface IForm {
   content: string;
@@ -115,25 +122,27 @@ const Page = ({
       });
       return;
     }
-    if (!fileList.every((file) => validImageExtensions.includes(file.type))) {
+
+    if (!fileList.every(isValidImageExtension)) {
       setToastPopup({
-        message: "지원되는 파일 형식은 JPEG, JPG, PNG, GIF입니다.",
+        message: PopupErrorMessage.UnsupportedFileType,
         top: false,
         success: false,
       });
       setError("photos", {
-        message: "지원되는 파일 형식은 JPEG, JPG, PNG, GIF입니다.",
+        message: PopupErrorMessage.UnsupportedFileType,
       });
       return;
     }
-    if (!fileList.every((file) => file.size <= 5 * MB)) {
+
+    if (!fileList.every(isValidImageSize)) {
       setToastPopup({
-        message: "사진 한 장의 크기는 최대 1MB 입니다.",
+        message: PopupErrorMessage.FileSizeExceeded,
         top: false,
         success: false,
       });
       setError("photos", {
-        message: "사진 한 장의 크기는 최대 1MB 입니다.",
+        message: PopupErrorMessage.FileSizeExceeded,
       });
       return;
     }
@@ -235,7 +244,7 @@ const Page = ({
                 <input
                   className="hidden"
                   type="file"
-                  accept={validImageExtensions.join(",")}
+                  accept={SUPPORTED_IMAGE_EXTENSIONS.join(",")}
                   multiple
                   {...register("photos", { onChange: onImageFilesChange })}
                 />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,25 +2,29 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-
 import axios, { HttpStatusCode } from "axios";
-import Button from "@/app/components/button";
-import defaultProfileImage from "@/public/default-profile.jpg";
-import apiManager from "@/api/apiManager";
-import { removeJwtFromSessionStorage } from "@/libs/jwt";
-import { MB, validImageExtensions } from "@/libs/constants";
-import { IApiResponseDto } from "@/types/api/apiResponse.interface";
 import { useSetRecoilState } from "recoil";
+
+import apiManager from "@/api/apiManager";
+import Button from "@/app/components/button";
 import { toastPopupAtom } from "@/hooks/atoms";
+import { IApiResponseDto } from "@/types/api/apiResponse.interface";
 import { PopupErrorMessage } from "@/types/enums";
+import { IProfileDTO } from "@/types/member";
+import { removeJwtFromSessionStorage } from "@/libs/jwt";
+import { SUPPORTED_IMAGE_EXTENSIONS } from "@/libs/constants";
+import {
+  isValidImageSize,
+  isValidImageExtension,
+} from "@/libs/imageUploadUtils";
+import defaultProfileImage from "@/public/default-profile.jpg";
 import withAuth from "../components/withAuth";
 import ConfirmModal from "../components/confirmModal";
 import Frame from "../components/frame";
-import { IProfileDTO } from "@/types/member";
-import Link from "next/link";
 
 interface IForm {
   nickname: string;
@@ -148,9 +152,8 @@ const Page = () => {
     if (!files || files.length <= 0) return;
 
     const file = files[0];
-    const fileType = file.type;
 
-    if (!validImageExtensions.includes(fileType)) {
+    if (!isValidImageExtension(file)) {
       setToastPopup({
         // @ts-ignore
         message: PopupErrorMessage.UnsupportedFileType,
@@ -160,7 +163,7 @@ const Page = () => {
       return;
     }
 
-    if (file.size > 1 * MB) {
+    if (!isValidImageSize(file)) {
       setToastPopup({
         // @ts-ignore
         message: PopupErrorMessage.FileSizeExceeded,
@@ -269,7 +272,7 @@ const Page = () => {
               <input
                 className="hidden"
                 type="file"
-                accept={validImageExtensions.join(",")}
+                accept={SUPPORTED_IMAGE_EXTENSIONS.join(",")}
                 {...register("profileImage", {
                   onChange: onProfileImageChange,
                 })}

--- a/src/libs/constants.ts
+++ b/src/libs/constants.ts
@@ -1,6 +1,7 @@
 export const MB = 1024 * 1024;
+export const MAX_FILE_SIZE = 10 * MB;
 
-export const validImageExtensions = [
+export const SUPPORTED_IMAGE_EXTENSIONS: string[] = [
   "image/jpeg",
   "image/jpg",
   "image/png",

--- a/src/libs/imageUploadUtils.ts
+++ b/src/libs/imageUploadUtils.ts
@@ -1,6 +1,8 @@
+import axios from "axios";
+
 import { imageInfo } from "@/app/challenges/[challengeId]/post/page";
 import { PhotoDTO } from "@/types/post";
-import axios from "axios";
+import { MAX_FILE_SIZE, SUPPORTED_IMAGE_EXTENSIONS } from "./constants";
 
 const uploadImageToS3 = async (
   preSignedUrl: string,
@@ -76,3 +78,11 @@ export function convertToPhotoDTO(imageInfoList: imageInfo[]): PhotoDTO[] {
     return photoDTO;
   });
 }
+
+export const isValidImageSize = (image: File): boolean => {
+  return 0 < image.size && image.size <= MAX_FILE_SIZE;
+};
+
+export const isValidImageExtension = (image: File): boolean => {
+  return SUPPORTED_IMAGE_EXTENSIONS.includes(image.type);
+};

--- a/src/types/enums/popupMessage.ts
+++ b/src/types/enums/popupMessage.ts
@@ -1,5 +1,15 @@
-export enum PopupErrorMessage {
-  ReLoginRequired = "다시 로그인 해 주세요",
-  UnsupportedFileType = "지원되는 파일 형식은 JPEG, JPG, PNG, GIF입니다.",
-  FileSizeExceeded = "파일 크기는 1MB를 초과할 수 없습니다.",
-}
+import {
+  MAX_FILE_SIZE,
+  MB,
+  SUPPORTED_IMAGE_EXTENSIONS,
+} from "@/libs/constants";
+
+const supportedFileTypes = SUPPORTED_IMAGE_EXTENSIONS.map(
+  (type) => type.split("/")[1]
+).join(", ");
+
+export const PopupErrorMessage = {
+  ReLoginRequired: "다시 로그인 해 주세요",
+  UnsupportedFileType: `지원되는 파일 형식은 ${supportedFileTypes} 입니다.`,
+  FileSizeExceeded: `파일 크기는 ${MAX_FILE_SIZE / MB}MB를 초과할 수 없습니다.`,
+} as const;


### PR DESCRIPTION
# 개요

게시물 업로드 이미지와 프로필 업로드 이미지 파일의 크기 제한을 상향합니다.
최신 기종 스마트폰의 사진 품질이 높아서 모바일에서 이미지를 업로드 하지 못하는 문제를 해결하기 위한 방안입니다. (10MB 넘는 경우도 있음)

## 게시물 업로드 이미지

||1개당 용량|개수|총 용량|
|---|---|---|---|
|기존|1MB|5개|5MB|
|변경|10MB|5개|50MB|

## 프로필 업로드 이미지

||1개당 용량|개수|총 용량|
|---|---|---|---|
|기존|1MB|1개|1MB|
|변경|10MB|1개|10MB|

# 작업 내용

## 1. `MAX_FILE_SIZE` 상수 추가

가독성 향상을 위해 이미지 최대 크기를 `constant.ts` 파일에 `MAX_FILE_SIZE` 상수로 설정했습니다.

### 기존 코드

```typescript
// constant.ts
export const MB = 1024 * 1024;

// page.tsx
if (file.size > 1 * MB) {
  // ...
}
```

### 변경 코드

```typescript
// constant.ts
export const MB = 1024 * 1024;
export const MAX_FILE_SIZE = 10 * MB;

// page.tsx
if (file.size > MAX_FILE_SIZE) {
  // ...
}
```

## 2. 이미지 유효성 검사 메서드 추출

이미지 유효성을 검사하는 조건문과 배열 순회 메서드에서 사용하는 콜백 메서드를 별도의 메서드로 추출하였습니다.

### 기존 코드

```typescript
// page.tsx
if (!fileList.every((file) => validImageExtensions.includes(file.type))) {
  // ...
}
```

### 변경 코드

```typescript
// imageUploadUtils.ts
export const isValidImageExtension = (image: File): boolean => {
  return SUPPORTED_IMAGE_EXTENSIONS.includes(image.type);
};

// page.tsx
if (!fileList.every(isValidImageExtension)) {
  // ...
}
```

## 3. 하드 코딩 에러 메세지 enum 변수로 대체

이미지 유효성 검사 시 표시하는 하드 코딩 되어 있던 오류 메세지를 일관성 향상을 위해 enum에 선언한 값으로 변경했습니다.

### 기존 코드

```typescript
// page.tsx
setToastPopup({
    message: "지원되는 파일 형식은 JPEG, JPG, PNG, GIF입니다.",
    top: false,
    success: false,
  });
  setError("photos", {
    message: "지원되는 파일 형식은 JPEG, JPG, PNG, GIF입니다.",
  });
  return;
}
```

### 변경 코드

```typescript
// page.tsx
setToastPopup({
  message: PopupErrorMessage.UnsupportedFileType,
  top: false,
  success: false,
});
setError("photos", {
  message: PopupErrorMessage.UnsupportedFileType,
});
return;
```

## 4. enum을 객체로 변경

기존에 enum으로 선언되어 있던 `PopupErrorMessage`를 객체로 변경했습니다. 
객체로 변경한 이유는 `constant.ts` 파일에 선언한 이미지 확장자와 이미지 파일 최대 크기를 동적으로 가져와서 문자열을 생성하기 위함입니다.
enum은 컴파일 시점에 리터럴 값으로 존재해야 하지만, 지원하는 이미지 형식 문자열을 `map()` 메서드를 이용해서 생성하다보니 런타임 시점에서 생성되어야 한다고 합니다. 

### 기존 코드

```typescript
// popupMessage.ts
export enum PopupErrorMessage {
  ReLoginRequired = "다시 로그인 해 주세요",
  UnsupportedFileType = "지원되는 파일 형식은 JPEG, JPG, PNG, GIF입니다.",
  FileSizeExceeded = "파일 크기는 1MB를 초과할 수 없습니다.",
}
```

### 변경 코드

```typescript
// popupMessage.ts
import {
  MAX_FILE_SIZE,
  MB,
  SUPPORTED_IMAGE_EXTENSIONS,
} from "@/libs/constants";

const supportedFileTypes = SUPPORTED_IMAGE_EXTENSIONS.map(
  (type) => type.split("/")[1]
).join(", ");

export const PopupErrorMessage = {
  ReLoginRequired: "다시 로그인 해 주세요",
  UnsupportedFileType: `지원되는 파일 형식은 ${supportedFileTypes} 입니다.`,
  FileSizeExceeded: `파일 크기는 ${MAX_FILE_SIZE / MB}MB를 초과할 수 없습니다.`,
} as const;
```