### PR TITLE
chore: sst aws provider 버전 변경 (6.52 -> latest) #152

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -9,7 +9,6 @@ export default $config({
       providers: {
         aws: {
           region: "ap-northeast-2",
-          version: "6.52.0",
         },
       },
     };


### PR DESCRIPTION
# 개요 
PR #148의 main 브랜치 병합 이후 아래의 오류가 발생했습니다.

> ✕  You specified version 6.52.0 of the "aws" provider. SST needs 6.65.0 or higher.Error: Failed to run: /root/repo/node_modules/.bin/sst deploy --stage production
    at shell (file:///tmp/buildspec/index.mjs:254:13)
    at Object.deploy (file:///tmp/buildspec/index.mjs:213:5)
    at workflow (file:///tmp/buildspec/index.mjs:377:69)

원인은 PR #109에서 버전을 6.55 대신 6.52로 고정하면서 발생한 것으로 추정하고 있습니다.

# 작업 내용

SST AWS Provider 버전을 6.52 에서 latest로 변경했습니다.