### PR TITLE
[refact] 현재 로그인한 사용자를 위한 변수명을 isCurrentUser로 변경 #154

### DIFF
--- a/src/app/challenges/[challengeId]/fee-table/page.tsx
+++ b/src/app/challenges/[challengeId]/fee-table/page.tsx
@@ -174,7 +174,7 @@ const Page = ({
                   key={index}
                   className={addClassNames(
                     "",
-                    participant.isMe ? "bg-habit-green" : "bg-white"
+                    participant.isCurrentUser ? "bg-habit-green" : "bg-white"
                   )}
                 >
                   <td className="px-4 py-4 whitespace-nowrap">{index + 1}</td>

--- a/src/types/challenge/challengeFeeList.interface.ts
+++ b/src/types/challenge/challengeFeeList.interface.ts
@@ -2,7 +2,7 @@ export interface MemberFeeView {
   nickname: string;
   totalFee: number;
   completionRate: number;
-  isMe: boolean;
+  isCurrentUser: boolean;
 }
 
 export interface IChallengeFeeListDto {


### PR DESCRIPTION
## 개요

* 백엔드에서 프론트로 보내는 데이터 내부 변수명에 변경이 있었습니다.
* 현재 로그인한 사용자를 의미하는 변수 `isCurrentUser`입니다.
* 변수명의 변경을 프론트에 적용합니다.

---

## 내용
---

### 1. `isCurrentUser` 변수명으로 변경

* 현재 사용자를 의미하는 변수인 `isCurrentUser`가 벡엔드의 `MemberFee` DTO에 존재합니다.
* 프론트에서는 `MemberFeeView` 인터페이스가 대응해 받고 있습니다.

```typescript
export interface MemberFeeView {
  nickname: string;
  totalFee: number;
  completionRate: number;
  isCurrentUser: boolean;
}
```

* 기존 `isMe`였던 변수명을 `isCurrentUser`로 변경합니다.

---

### 기타

* VScode의 검색 기능으로 해당 변수 위치를 확인해 변경했고, 개발 서버에서 잘 작동하는 것도 확인하였지만,,
* 혹시 수정할 때 제가 모르는 무언가가 있을까봐 확인받고 (백엔드와 바로 이어서) 머지하겠읍니다.

---

### 사족

* 내용이 워낙 간단한 것이라 해보았읍니다.
* 미리 감사드립니다.