### PR TITLE
Feat/participants list page#146

### DIFF
--- a/src/api/challenge.ts
+++ b/src/api/challenge.ts
@@ -13,10 +13,11 @@ export const fetchChallengeDetails = async (
   return data;
 };
 
-export const fetchEnrolledChallenges = async (): Promise<
-  IChallengeEnrolledListItemDto[]
-> => {
-  const res = await apiManager.get(`/challenges/me`);
+export const fetchEnrolledChallenges = async (
+  userId?: string
+): Promise<IChallengeEnrolledListItemDto[]> => {
+  const endpoint = userId ? `/challenges/members/${userId}` : `/challenges/me`;
+  const res = await apiManager.get(endpoint);
   const { data }: { data: IChallengeEnrolledListItemDto[] } = res.data;
   console.log(data);
   return data;

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -5,9 +5,10 @@ export const fetchMemberProfile = async (
   userId?: string
 ): Promise<IProfileDTO | null> => {
   try {
-    const endpoint = userId ? `/member/${userId}` : `/member`;
+    const endpoint = userId ? `/members/${userId}` : `/member`;
+    console.log(endpoint);
     const res = await apiManager.get(endpoint);
-    const { data }: { data: IProfileDTO } = res.data;
+    const data: IProfileDTO = res.data.data;
     console.log(data);
     return data;
   } catch (error) {

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,9 +1,12 @@
 import apiManager from "@/api/apiManager";
 import { IProfileDTO } from "@/types/member";
 
-export const fetchMemberProfile = async (): Promise<IProfileDTO | null> => {
+export const fetchMemberProfile = async (
+  userId?: string
+): Promise<IProfileDTO | null> => {
   try {
-    const res = await apiManager.get(`/member`);
+    const endpoint = userId ? `/member/${userId}` : `/member`;
+    const res = await apiManager.get(endpoint);
     const { data }: { data: IProfileDTO } = res.data;
     console.log(data);
     return data;

--- a/src/app/[userId]/challenge/page.tsx
+++ b/src/app/[userId]/challenge/page.tsx
@@ -34,6 +34,9 @@ const Page = ({ params: { userId } }: { params: { userId: string } }) => {
       <div className="flex flex-col max-w-xl px-5 mx-auto">
         <div className="flex items-center justify-between mb-3">
           <div className="flex flex-col">
+            {memberProfile.isCurrentUser && (
+              <span className="text-gray-400">안녕하세요</span>
+            )}
             <h2 className="text-lg font-semibold">{memberProfile.nickname}</h2>
           </div>
           <Image
@@ -48,8 +51,11 @@ const Page = ({ params: { userId } }: { params: { userId: string } }) => {
           <span className="mb-2 text-sm font-light">
             {format(new Date(), "yyyy년 MM월 dd일")}
           </span>
-
-          <h3 className="mb-5 text-lg font-semibold">{`${memberProfile.nickname}의 챌린지`}</h3>
+          {memberProfile.isCurrentUser ? (
+            <h3 className="mb-5 text-lg font-semibold">나의 챌린지</h3>
+          ) : (
+            <h3 className="mb-5 text-lg font-semibold">{`${memberProfile.nickname}의 챌린지`}</h3>
+          )}
 
           <div className="flex items-center mb-2 space-x-2">
             <ChallengeStateSelector

--- a/src/app/[userId]/challenge/page.tsx
+++ b/src/app/[userId]/challenge/page.tsx
@@ -18,10 +18,7 @@ import ChallengeStateSelector from "@/app/challenges/my-challenge/components/cha
 import Challenges from "@/app/challenges/my-challenge/components/challenges";
 
 const Page = ({ params: { userId } }: { params: { userId: string } }) => {
-  // 내 닉네임과 프로필url을 불러오는 단순한 api
-  // userId를 통한 정보를 불러오는 api필요.
-  const { memberProfile, isLoading, error } = useMemberProfile();
-  // 내 챌린지 목록을 불러오는 핵심 api
+  const { memberProfile, isLoading, error } = useMemberProfile(userId);
   const { challengeEnrolledList } = useChallengeEnrolledList(userId);
   const [challengeStateSelection, setChallengeStateSelection] =
     useState<ChallengeStatesEnum>(ChallengeStatesEnum.InProgress);
@@ -37,7 +34,6 @@ const Page = ({ params: { userId } }: { params: { userId: string } }) => {
       <div className="flex flex-col max-w-xl px-5 mx-auto">
         <div className="flex items-center justify-between mb-3">
           <div className="flex flex-col">
-            <span className="text-gray-400">안녕하세요</span>
             <h2 className="text-lg font-semibold">{memberProfile.nickname}</h2>
           </div>
           <Image
@@ -53,7 +49,7 @@ const Page = ({ params: { userId } }: { params: { userId: string } }) => {
             {format(new Date(), "yyyy년 MM월 dd일")}
           </span>
 
-          <h3 className="mb-5 text-lg font-semibold">나의 챌린지</h3>
+          <h3 className="mb-5 text-lg font-semibold">{`${memberProfile.nickname}의 챌린지`}</h3>
 
           <div className="flex items-center mb-2 space-x-2">
             <ChallengeStateSelector
@@ -65,6 +61,7 @@ const Page = ({ params: { userId } }: { params: { userId: string } }) => {
           <Challenges
             challenges={challengeEnrolledList}
             challengeState={challengeStateSelection}
+            isCurrentUser={memberProfile.isCurrentUser}
           />
         </div>
       </div>

--- a/src/app/[userId]/challenge/page.tsx
+++ b/src/app/[userId]/challenge/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Image from "next/image";
+
+import { format } from "date-fns";
+
+import FloatingButton from "@/app/components/floatingButton";
+import { useMemberProfile } from "@/hooks/useMemberProfile";
+import { useChallengeEnrolledList } from "@/hooks/useChallengeEnrolledList";
+import { ChallengeStatesEnum } from "@/types/enums";
+
+import defaultProfileImage from "@/public/default-profile.jpg";
+import withAuth from "@/app/components/withAuth";
+import Frame from "@/app/components/frame";
+import Loading from "@/app/challenges/my-challenge/loading";
+import ChallengeStateSelector from "@/app/challenges/my-challenge/components/challengeStateSelector";
+import Challenges from "@/app/challenges/my-challenge/components/challenges";
+
+const Page = ({ params: { userId } }: { params: { userId: string } }) => {
+  // 내 닉네임과 프로필url을 불러오는 단순한 api
+  // userId를 통한 정보를 불러오는 api필요.
+  const { memberProfile, isLoading, error } = useMemberProfile();
+  // 내 챌린지 목록을 불러오는 핵심 api
+  const { challengeEnrolledList } = useChallengeEnrolledList(userId);
+  const [challengeStateSelection, setChallengeStateSelection] =
+    useState<ChallengeStatesEnum>(ChallengeStatesEnum.InProgress);
+  useEffect(() => {
+    document.title = "My Challenge | HabitPay";
+  }, []);
+  if (memberProfile === null || challengeEnrolledList === null) {
+    return <Loading />;
+  }
+
+  return (
+    <Frame hasTabBar>
+      <div className="flex flex-col max-w-xl px-5 mx-auto">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-col">
+            <span className="text-gray-400">안녕하세요</span>
+            <h2 className="text-lg font-semibold">{memberProfile.nickname}</h2>
+          </div>
+          <Image
+            className="object-cover bg-white rounded-full shadow-md size-16 shadow-slate-400"
+            src={memberProfile.imageUrl || defaultProfileImage}
+            width={64}
+            height={64}
+            alt="Picture of Avatar"
+          />
+        </div>
+        <div className="flex flex-col mb-10">
+          <span className="mb-2 text-sm font-light">
+            {format(new Date(), "yyyy년 MM월 dd일")}
+          </span>
+
+          <h3 className="mb-5 text-lg font-semibold">나의 챌린지</h3>
+
+          <div className="flex items-center mb-2 space-x-2">
+            <ChallengeStateSelector
+              challengeStateSelection={challengeStateSelection}
+              setter={setChallengeStateSelection}
+            />
+          </div>
+
+          <Challenges
+            challenges={challengeEnrolledList}
+            challengeState={challengeStateSelection}
+          />
+        </div>
+      </div>
+    </Frame>
+  );
+};
+
+export default withAuth(Page);

--- a/src/app/challenges/[challengeId]/main/page.tsx
+++ b/src/app/challenges/[challengeId]/main/page.tsx
@@ -285,22 +285,24 @@ const Page = ({
             ) : (
               <>
                 <PostsFeed id={challengeId} />
-                <FloatingButton href={`${getParentPath(pathname)}/post`}>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="size-7"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
-                    />
-                  </svg>
-                </FloatingButton>
+                {challengeDetails.isMemberEnrolledInChallenge && (
+                  <FloatingButton href={`${getParentPath(pathname)}/post`}>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="size-7"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
+                      />
+                    </svg>
+                  </FloatingButton>
+                )}
               </>
             )}
           </div>

--- a/src/app/challenges/[challengeId]/participants/page.tsx
+++ b/src/app/challenges/[challengeId]/participants/page.tsx
@@ -5,35 +5,46 @@ import { useChallengeDetails } from "@/hooks/useChallengeDetails";
 import Image from "next/image";
 import defaultProfileImage from "@/public/default-profile.jpg";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import apiManager from "@/api/apiManager";
+import { ChallengeMembersResponseDTO, MemberDTO } from "@/types/challenge";
 
 const Page = ({
   params: { challengeId },
 }: {
   params: { challengeId: string };
 }) => {
-  const { challengeDetails, selectedDays, isLoading, error } =
-    useChallengeDetails(challengeId);
+  const [members, setMembers] = useState<MemberDTO[]>([]);
+  useEffect(() => {
+    document.title = "Members | HabitPay";
+    const getMembers = async () => {
+      const res = await apiManager.get(`/challenges/${challengeId}/members`);
+      const data: ChallengeMembersResponseDTO = res.data.data;
+      setMembers(data);
+    };
+    getMembers();
+  }, [challengeId]);
 
   return (
     <Frame canGoBack title="참여자 목록" isBorder>
       <div className="flex flex-col max-w-xl px-5 py-3 mx-auto space-y-4">
-        {challengeDetails?.enrolledMembersProfileImageList.map(
-          (item, index) => (
+        {members &&
+          members.map((member, index) => (
             <Link
-              href={`${item}`}
+              href={`/${member.memberId}/challenge`}
               key={index}
-              className="bg-white rounded-lg px-3 py-2"
+              className="flex items-center gap-3 px-3 py-2 bg-white rounded-lg"
             >
               <Image
-                className="rounded-full size-16 object-cover shadow-md shadow-slate-400 bg-habit-gray"
-                src={item || defaultProfileImage}
+                className="object-cover rounded-full shadow-md size-16 shadow-slate-400 bg-habit-gray"
+                src={member.profileImageUrl || defaultProfileImage}
                 width={64}
                 height={64}
                 alt="Picture of Avatar"
               />
+              <div>{member.nickname}</div>
             </Link>
-          )
-        )}
+          ))}
       </div>
     </Frame>
   );

--- a/src/app/challenges/my-challenge/components/challengeCard.tsx
+++ b/src/app/challenges/my-challenge/components/challengeCard.tsx
@@ -10,9 +10,14 @@ import { calculateTimeRemaining } from "@/libs/utils";
 interface IChallengeCardProps {
   items: IChallengeEnrolledListItemDto[];
   challengeState: ChallengeStatesEnum;
+  isCurrentUser: boolean;
 }
 
-function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
+function ChallengeCard({
+  items,
+  challengeState,
+  isCurrentUser,
+}: IChallengeCardProps) {
   const now = new Date();
   return (
     <>
@@ -34,7 +39,7 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
                   <div className="flex items-center space-x-4">
                     <div className="flex items-center -space-x-2">
                       <Image
-                        className="z-10 rounded-full size-12 object-cover shadow-md shadow-slate-400  bg-habit-gray"
+                        className="z-10 object-cover rounded-full shadow-md size-12 shadow-slate-400 bg-habit-gray"
                         src={item.hostProfileImage || defaultProfileImage}
                         width={48}
                         height={48}
@@ -54,7 +59,8 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
                     <div className="flex flex-col">
                       <h3 className="text-lg font-bold">{item.title}</h3>
                       {challengeState == ChallengeStatesEnum.InProgress &&
-                        item.isParticipatedToday && (
+                        item.isParticipatedToday &&
+                        isCurrentUser && (
                           <span className="text-sm text-habit-green">
                             참여 완료
                           </span>
@@ -62,7 +68,8 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
 
                       {challengeState == ChallengeStatesEnum.InProgress &&
                         item.isTodayParticipatingDay &&
-                        !item.isParticipatedToday && (
+                        !item.isParticipatedToday &&
+                        isCurrentUser && (
                           <span className="text-sm text-habit-gray">
                             아직 참여하지 않으셨습니다.
                           </span>
@@ -178,7 +185,8 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
 
             {challengeState == ChallengeStatesEnum.InProgress &&
               item.isTodayParticipatingDay &&
-              item.isParticipatedToday && (
+              item.isParticipatedToday &&
+              isCurrentUser && (
                 <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-gray  rounded-xl">
                   이미 참여했습니다.
                 </button>
@@ -186,7 +194,8 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
 
             {challengeState == ChallengeStatesEnum.InProgress &&
               item.isTodayParticipatingDay &&
-              !item.isParticipatedToday && (
+              !item.isParticipatedToday &&
+              isCurrentUser && (
                 <Link
                   href={`/challenges/${item.challengeId}/post`}
                   className="w-full py-[6px] text-sm font-thin text-center text-white bg-habit-green rounded-xl"
@@ -196,23 +205,26 @@ function ChallengeCard({ items, challengeState }: IChallengeCardProps) {
               )}
 
             {challengeState == ChallengeStatesEnum.InProgress &&
-              !item.isTodayParticipatingDay && (
+              !item.isTodayParticipatingDay &&
+              isCurrentUser && (
                 <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-gray rounded-xl">
                   오늘은 참여하는 날이 아닙니다.
                 </button>
               )}
 
-            {challengeState === ChallengeStatesEnum.Scheduled && (
-              <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-gray rounded-xl">
-                아직 시작하지 않은 챌린지입니다
-              </button>
-            )}
+            {challengeState === ChallengeStatesEnum.Scheduled &&
+              isCurrentUser && (
+                <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-gray rounded-xl">
+                  아직 시작하지 않은 챌린지입니다
+                </button>
+              )}
 
-            {challengeState === ChallengeStatesEnum.Completed && (
-              <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-gray rounded-xl">
-                종료된 챌린지입니다
-              </button>
-            )}
+            {challengeState === ChallengeStatesEnum.Completed &&
+              isCurrentUser && (
+                <button className="w-full py-[6px] text-sm font-thin text-white bg-habit-gray rounded-xl">
+                  종료된 챌린지입니다
+                </button>
+              )}
           </div>
         );
       })}

--- a/src/app/challenges/my-challenge/components/challenges.tsx
+++ b/src/app/challenges/my-challenge/components/challenges.tsx
@@ -8,9 +8,14 @@ import {
 interface IChallengesProps {
   challenges: IChallengeEnrolledList;
   challengeState: ChallengeStatesEnum;
+  isCurrentUser: boolean;
 }
 
-function Challenges({ challenges, challengeState }: IChallengesProps) {
+function Challenges({
+  challenges,
+  challengeState,
+  isCurrentUser,
+}: IChallengesProps) {
   const sortByStartDateAsc = (
     a: IChallengeEnrolledListItemDto,
     b: IChallengeEnrolledListItemDto
@@ -36,6 +41,7 @@ function Challenges({ challenges, challengeState }: IChallengesProps) {
           <ChallengeCard
             items={challenges.inProgress.sort(sortByStartDateDesc)}
             challengeState={challengeState}
+            isCurrentUser={isCurrentUser}
           />
         )}
 
@@ -52,6 +58,7 @@ function Challenges({ challenges, challengeState }: IChallengesProps) {
           <ChallengeCard
             items={challenges.scheduled.sort(sortByStartDateDesc)}
             challengeState={challengeState}
+            isCurrentUser={isCurrentUser}
           />
         )}
 
@@ -66,6 +73,7 @@ function Challenges({ challenges, challengeState }: IChallengesProps) {
         <ChallengeCard
           items={challenges.completed.sort(sortByStartDateDesc)}
           challengeState={challengeState}
+          isCurrentUser={isCurrentUser}
         />
       )}
     </>

--- a/src/app/challenges/my-challenge/page.tsx
+++ b/src/app/challenges/my-challenge/page.tsx
@@ -41,7 +41,7 @@ function Page() {
             <h2 className="text-lg font-semibold">{memberProfile.nickname}</h2>
           </div>
           <Image
-            className="rounded-full size-16 object-cover shadow-md shadow-slate-400 bg-white"
+            className="object-cover bg-white rounded-full shadow-md size-16 shadow-slate-400"
             src={memberProfile.imageUrl || defaultProfileImage}
             width={64}
             height={64}
@@ -65,6 +65,7 @@ function Page() {
           <Challenges
             challenges={challengeEnrolledList}
             challengeState={challengeStateSelection}
+            isCurrentUser={memberProfile.isCurrentUser}
           />
         </div>
       </div>

--- a/src/hooks/useChallengeEnrolledList.ts
+++ b/src/hooks/useChallengeEnrolledList.ts
@@ -21,7 +21,7 @@ const categorizeChallenge = (
   return ChallengeStatesEnum.InProgress;
 };
 
-export const useChallengeEnrolledList = () => {
+export const useChallengeEnrolledList = (userId?: string) => {
   const [challengeEnrolledList, setChallengeEnrolledList] =
     useState<IChallengeEnrolledList | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -30,7 +30,7 @@ export const useChallengeEnrolledList = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const data = await fetchEnrolledChallenges();
+        const data = await fetchEnrolledChallenges(userId);
         if (data) {
           const categorizedData: IChallengeEnrolledList = {
             inProgress: [],

--- a/src/hooks/useMemberProfile.ts
+++ b/src/hooks/useMemberProfile.ts
@@ -11,8 +11,10 @@ export const useMemberProfile = (userId?: string) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const data = await fetchMemberProfile();
-        if (data) {
+        const data = await fetchMemberProfile(userId);
+        if (data && !userId) {
+          setMemberProfile({ ...data, isCurrentUser: true });
+        } else {
           setMemberProfile(data);
         }
       } catch (err) {
@@ -23,7 +25,7 @@ export const useMemberProfile = (userId?: string) => {
     };
 
     fetchData();
-  }, []);
+  }, [userId]);
 
   return { memberProfile, isLoading, error };
 };

--- a/src/hooks/useMemberProfile.ts
+++ b/src/hooks/useMemberProfile.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { IProfileDTO } from "@/types/member";
 import { fetchMemberProfile } from "@/api/member";
 
-export const useMemberProfile = () => {
+export const useMemberProfile = (userId?: string) => {
   const [memberProfile, setMemberProfile] = useState<IProfileDTO | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);

--- a/src/types/challenge/challengeMembersResponse.interface.ts
+++ b/src/types/challenge/challengeMembersResponse.interface.ts
@@ -1,0 +1,8 @@
+export interface MemberDTO {
+  memberId: number;
+  nickname: string;
+  profileImageUrl: string;
+  isCurrentUser: boolean;
+}
+
+export type ChallengeMembersResponseDTO = MemberDTO[];

--- a/src/types/challenge/index.ts
+++ b/src/types/challenge/index.ts
@@ -6,3 +6,4 @@ export * from "./challengeContentResponse.interface";
 export * from "./challengeFeeList.interface";
 export * from "./challengeListResponse.interface";
 export * from "./challengeParticipation.interface";
+export * from "./challengeMembersResponse.interface";

--- a/src/types/member/profile.interface.ts
+++ b/src/types/member/profile.interface.ts
@@ -1,4 +1,5 @@
 export interface IProfileDTO {
   nickname: string;
   imageUrl: string;
+  isCurrentUser: boolean;
 }

--- a/src/types/member/profile.interface.ts
+++ b/src/types/member/profile.interface.ts
@@ -1,4 +1,5 @@
 export interface IProfileDTO {
+  memberId: number;
   nickname: string;
   imageUrl: string;
   isCurrentUser: boolean;


### PR DESCRIPTION
![스크린샷 2025-01-08 18 07 50](https://github.com/user-attachments/assets/a45d9881-4f4e-472d-ac7f-5eb3ab21ee50)
참여자 목록페이지에 닉네임과 프로필사진이 표시되도록 만들었으며,
클릭하면
![스크린샷 2025-01-08 18 08 16](https://github.com/user-attachments/assets/7a680660-ccfb-4977-8fb2-1bfc11b40e8f)
이렇게 특정 멤버의 챌린지들을 염탐 할 수 있게되었습니다.
![스크린샷 2025-01-08 18 09 01](https://github.com/user-attachments/assets/a3b8f99b-a9c4-436b-a2a5-29d774caec40)
![스크린샷 2025-01-08 18 09 09](https://github.com/user-attachments/assets/966575da-1064-4ab7-8ed8-7e03485a5aa2)
멤버의 목록을 눌러서 내 챌린지 목록페이지와,
홈을 눌러서 연결되는 내 챌린지 목록이 완전히 같은 페이지를 보여주는데요,
challenges/my-challenge페이지를 삭제 해도 되지 않을까 싶습니다.
기존 함수들을 수정하여 재활용할수있게 만들다보니
challenges/my-challenge페이지가 필요없게되었습니다.
[memberId]/challenge로 통합할수있을것같습니다.
다만 이렇게되면 내 memberId를 불러오는 api가 필요할 것 같습니다. 의견을 여쭙습니다.