### PR TITLE
[feat] 챌린지 목록 페이지에 총 참여 일수 표시#164

### DIFF
--- a/src/app/challenges/challenge-list/page.tsx
+++ b/src/app/challenges/challenge-list/page.tsx
@@ -20,11 +20,11 @@ import ChallengeList from "@/app/components/challengeList";
 function Page() {
   // TODO: 다른 hook 들과 겹치지 않도록 컴포넌트 분리하기
   const { memberProfile, isLoading, error } = useMemberProfile();
-  const { challengeEnrolledList } = useChallengeEnrolledList();
+
   useEffect(() => {
     document.title = "Challenge List | HabitPay";
   }, []);
-  if (memberProfile === null || challengeEnrolledList === null) {
+  if (memberProfile === null) {
     return <Loading />;
   }
 

--- a/src/app/components/challengeList.tsx
+++ b/src/app/components/challengeList.tsx
@@ -103,7 +103,7 @@ export default function ChallengeList() {
                   </div>
                   <div className="flex  *:text-sm">
                     <span className="font-bold">총 기간(일): </span>
-                    <span>{challenge.participatingDays}</span>
+                    <span>{challenge.totalParticipatingDaysCount}</span>
                   </div>
                 </Link>
               ))}

--- a/src/types/challenge/challengeListResponse.interface.ts
+++ b/src/types/challenge/challengeListResponse.interface.ts
@@ -7,6 +7,7 @@ export interface ChallengeListContentDTO {
   stopDate: string | null;
   numberOfParticipants: number;
   participatingDays: number;
+  totalParticipatingDaysCount: number;
   isStarted: boolean;
   isEnded: boolean;
   hostNickname: string;


### PR DESCRIPTION
# 개요

`/challenges/challenge-list` 페이지에서 현재 `총 참여 일수`가 챌린지 진행 요일을 비트로 저장한 값으로 표시되고 있습니다.
백엔드에서 전체 기간 동안 챌린지에 참여해야 하는 일수를 계산해서 보내준 DTO로 변경합니다.