### PR TITLE
포스트 날짜 표시 수정완료#160

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -10,6 +10,7 @@ import {
   differenceInDays,
   differenceInHours,
   differenceInMinutes,
+  format,
 } from "date-fns";
 
 // return은 "hogkim jkwak surlee"가 된다.
@@ -91,8 +92,10 @@ export function formatToTimeAgo(date: string): string {
     return formatter.format(Math.round(diff / MIN), "minutes");
   } else if (-diff <= DAY) {
     return formatter.format(Math.round(diff / HOUR), "hours");
-  } else {
+  } else if (-diff <= DAY * 7) {
     return formatter.format(Math.round(diff / DAY), "days");
+  } else {
+    return format(new Date(time), "yyyy.MM.dd HH:mm");
   }
 }
 


### PR DESCRIPTION
```typescript
  if (-diff <= MIN) {
    return formatter.format(Math.round(diff / SEC), "seconds");
  } else if (-diff <= HOUR) {
    return formatter.format(Math.round(diff / MIN), "minutes");
  } else if (-diff <= DAY) {
    return formatter.format(Math.round(diff / HOUR), "hours");
  } else if (-diff <= DAY * 7) {
    return formatter.format(Math.round(diff / DAY), "days");
  } else {
    return format(new Date(time), "yyyy.MM.dd HH:mm");
  }
```
현재 시간과 차이가 DAY*7 이하일 경우만 몇일전으로 표시되며,
그 이후는 yyyy.MM.dd HH:mm 형식으로 표기하도록 바꿨습니다.