### PR TITLE
챌린지 생성 버튼 활성화#169

### DIFF
--- a/src/app/[userId]/challenge/page.tsx
+++ b/src/app/[userId]/challenge/page.tsx
@@ -15,6 +15,7 @@ import Frame from "@/app/components/frame";
 import Loading from "./loading";
 import Challenges from "./components/challenges";
 import ChallengeStateSelector from "./components/challengeStateSelector";
+import FloatingButton from "@/app/components/floatingButton";
 
 const Page = ({ params: { userId } }: { params: { userId: string } }) => {
   const { memberProfile, isLoading, error } = useMemberProfile(userId);
@@ -70,6 +71,27 @@ const Page = ({ params: { userId } }: { params: { userId: string } }) => {
           />
         </div>
       </div>
+      {memberProfile.isCurrentUser && (
+        <FloatingButton href="/challenges/create-challenge">
+          <div className="flex items-center justify-center text-sm">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-4 h-4"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 4.5v15m7.5-7.5h-15"
+              />
+            </svg>
+            <span>챌린지 생성</span>
+          </div>
+        </FloatingButton>
+      )}
     </Frame>
   );
 };


### PR DESCRIPTION
챌린지 생성 버튼이 사려졌었습니다.
다른 멤버의 챌린지를 보는 페이지라서 없는게 낫다고 판단하여 삭제했었는데,
페이지를 통합하면서 다시 살릴 생각을 못하였습니다.
나의 챌린지 페이지를 볼 경우 챌린지 생성버튼이 보이도록 하였습니다.
![스크린샷 2025-01-09 19 15 08](https://github.com/user-attachments/assets/e1b59a4a-11f5-439b-98f9-0b69a7662407)
![스크린샷 2025-01-09 19 15 18](https://github.com/user-attachments/assets/4bc99bc2-1d3a-480a-962d-917506c3fc44)
